### PR TITLE
Support for additional/missing custom properties and capabilities within the citrix_machine_catalog resource

### DIFF
--- a/internal/daas/machine_catalog/machine_catalog_resource_model.go
+++ b/internal/daas/machine_catalog/machine_catalog_resource_model.go
@@ -79,6 +79,11 @@ type GalleryImageModel struct {
 	Version    types.String `tfsdk:"version"`
 }
 
+type PlaceImageInGalleryModel struct {
+	ReplicaRatio   types.Int64 `tfsdk:"replica_ratio"`
+	ReplicaMaximum types.Int64 `tfsdk:"replica_maximum"`
+}
+
 // WritebackCacheModel maps the write back cacheconfiguration schema data.
 type WritebackCacheModel struct {
 	PersistWBC                 types.Bool   `tfsdk:"persist_wbc"`

--- a/internal/daas/machine_catalog/machine_config.go
+++ b/internal/daas/machine_catalog/machine_config.go
@@ -14,15 +14,19 @@ type AzureMachineConfigModel struct {
 	ServiceOffering types.String `tfsdk:"service_offering"`
 	MasterImage     types.String `tfsdk:"master_image"`
 	/** Azure Hypervisor **/
-	ResourceGroup    types.String         `tfsdk:"resource_group"`
-	StorageAccount   types.String         `tfsdk:"storage_account"`
-	Container        types.String         `tfsdk:"container"`
-	GalleryImage     *GalleryImageModel   `tfsdk:"gallery_image"`
-	VdaResourceGroup types.String         `tfsdk:"vda_resource_group"`
-	StorageType      types.String         `tfsdk:"storage_type"`
-	UseManagedDisks  types.Bool           `tfsdk:"use_managed_disks"`
-	MachineProfile   *MachineProfileModel `tfsdk:"machine_profile"`
-	WritebackCache   *WritebackCacheModel `tfsdk:"writeback_cache"`
+	ResourceGroup       types.String              `tfsdk:"resource_group"`
+	StorageAccount      types.String              `tfsdk:"storage_account"`
+	Container           types.String              `tfsdk:"container"`
+	GalleryImage        *GalleryImageModel        `tfsdk:"gallery_image"`
+	VdaResourceGroup    types.String              `tfsdk:"vda_resource_group"`
+	StorageType         types.String              `tfsdk:"storage_type"`
+	UseManagedDisks     types.Bool                `tfsdk:"use_managed_disks"`
+	UseEphemeralOsDisk  types.Bool                `tfsdk:"use_ephemeral_os_disk"`
+	LicenseType         types.String              `tfsdk:"license_type"`
+	PlaceImageInGallery *PlaceImageInGalleryModel `tfsdk:"place_image_in_gallery"`
+	DiskEncryptionSetId types.String              `tfsdk:"disk_encryption_set_id"`
+	MachineProfile      *MachineProfileModel      `tfsdk:"machine_profile"`
+	WritebackCache      *WritebackCacheModel      `tfsdk:"writeback_cache"`
 }
 
 type AwsMachineConfigModel struct {
@@ -109,6 +113,22 @@ func (mc *AzureMachineConfigModel) RefreshProperties(catalog citrixorchestration
 			mc.StorageType = types.StringValue(stringPair.GetValue())
 		case "UseManagedDisks":
 			mc.UseManagedDisks = util.StringToTypeBool(stringPair.GetValue())
+		case "UseEphemeralOsDisk":
+			mc.UseEphemeralOsDisk = util.StringToTypeBool(stringPair.GetValue())
+		case "LicenseType":
+			if !mc.LicenseType.IsNull() || stringPair.GetValue() != "" {
+				mc.LicenseType = types.StringValue(stringPair.GetValue())
+			}
+		case "SharedImageGalleryReplicaRatio":
+			if mc.PlaceImageInGallery != nil {
+				mc.PlaceImageInGallery.ReplicaRatio = util.StringToTypeInt64(stringPair.GetValue())
+			}
+		case "SharedImageGalleryReplicaMaximum":
+			if mc.PlaceImageInGallery != nil {
+				mc.PlaceImageInGallery.ReplicaMaximum = util.StringToTypeInt64(stringPair.GetValue())
+			}
+		case "DiskEncryptionSetId":
+			mc.DiskEncryptionSetId = types.StringValue(stringPair.GetValue())
 		case "ResourceGroups":
 			mc.VdaResourceGroup = types.StringValue(stringPair.GetValue())
 		case "WBCDiskStorageType":

--- a/internal/util/common.go
+++ b/internal/util/common.go
@@ -193,6 +193,15 @@ func TypeBoolToString(from types.Bool) string {
 }
 
 // <summary>
+// Helper function to convert terraform int64 value to string
+// </summary>
+// <param name="from">Integer value in terraform int64</param>
+// <returns>Integer value in string</returns>
+func TypeInt64ToString(from types.Int64) string {
+	return strconv.FormatInt(from.ValueInt64(), 10)
+}
+
+// <summary>
 // Helper function to convert string to terraform boolean value
 // </summary>
 // <param name="from">Boolean value in string</param>
@@ -200,6 +209,16 @@ func TypeBoolToString(from types.Bool) string {
 func StringToTypeBool(from string) types.Bool {
 	result, _ := strconv.ParseBool(from)
 	return types.BoolValue(result)
+}
+
+// <summary>
+// Helper function to convert string to terraform integer value
+// </summary>
+// <param name="from">Integer value in string</param>
+// <returns>Integer value in terraform types.Int64</returns>
+func StringToTypeInt64(from string) types.Int64 {
+	result, _ := strconv.ParseInt(from, 10, 64)
+	return types.Int64Value(result)
 }
 
 // <summary>


### PR DESCRIPTION
Specifically, I focused on the azure_machine_config context, to address the following:

LicenseType
UseSharedImageGallery
SharedImageGalleryReplicaRatio
SharedImageGalleryReplicaMaximum
UseEphemeralOsDisk
DiskEncryptionSetId

As previously stated, the associated code is not fully tested or documented. While it serves my intended concept or use case, there may be unknown issues, and its applicability in all scenarios is not guaranteed. However, I have made efforts to align with the established coding practices and overall theme as outlined, wherever possible.