### PR TITLE
Support for Azure template spec as machine profile within the citrix_machine_catalog resource

### DIFF
--- a/internal/daas/machine_catalog/machine_catalog_resource_model.go
+++ b/internal/daas/machine_catalog/machine_catalog_resource_model.go
@@ -67,6 +67,8 @@ type ProvisioningSchemeModel struct {
 type MachineProfileModel struct {
 	MachineProfileVmName        types.String `tfsdk:"machine_profile_vm_name"`
 	MachineProfileResourceGroup types.String `tfsdk:"machine_profile_resource_group"`
+	AzureTemplateSpecName       types.String `tfsdk:"azure_template_spec_name"`
+	AzureTemplateSpecVersion    types.String `tfsdk:"azure_template_spec_version"`
 }
 
 type MachineDomainIdentityModel struct {

--- a/internal/daas/machine_catalog/machine_catalog_schema_utils.go
+++ b/internal/daas/machine_catalog/machine_catalog_schema_utils.go
@@ -320,11 +320,32 @@ func getSchemaForMachineCatalogResource() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"machine_profile_vm_name": schema.StringAttribute{
 										Description: "The name of the machine profile virtual machine.",
-										Required:    true,
+										Optional:    true,
 									},
 									"machine_profile_resource_group": schema.StringAttribute{
 										Description: "The resource group name where machine profile VM is located in.",
 										Required:    true,
+									},
+									"azure_template_spec_name": schema.StringAttribute{
+										Description: "The name of the Azure template spec.",
+										Optional:    true,
+										Validators: []validator.String{
+											stringvalidator.ExactlyOneOf(path.Expressions{
+												path.MatchRelative().AtParent().AtName("machine_profile_vm_name"),
+											}...),
+											stringvalidator.AlsoRequires(path.Expressions{
+												path.MatchRelative().AtParent().AtName("azure_template_spec_version"),
+											}...),
+										},
+									},
+									"azure_template_spec_version": schema.StringAttribute{
+										Description: "The version of the Azure template spec.",
+										Optional:    true,
+										Validators: []validator.String{
+											stringvalidator.ConflictsWith(path.Expressions{
+												path.MatchRelative().AtParent().AtName("machine_profile_vm_name"),
+											}...),
+										},
 									},
 								},
 							},

--- a/internal/util/common.go
+++ b/internal/util/common.go
@@ -65,6 +65,7 @@ const SnapshotResourceType string = "Snapshot"
 const VhdResourceType string = "Vhd"
 const VirtualPrivateCloudResourceType string = "VirtualPrivateCloud"
 const VirtualMachineResourceType string = "Vm"
+const TemplateSpecVersionResourceType string = "TemplateSpecVersion"
 
 // Terraform model for name value string pair
 type NameValueStringPairModel struct {


### PR DESCRIPTION
Specifically, this adds two new attributes to the Azure-related `machine_profile` block, allowing the use of a template spec name and version as an alternative to the virtual machine name.

Once again, the associated code is not fully tested or documented. While it serves my intended concept or use case, there may be unknown issues, and its applicability in all scenarios is not guaranteed. However, I have made efforts to align with the established coding practices and overall theme as outlined, wherever possible.