### PR TITLE
Fix onboarding script and null pointer exception in machine config 

### DIFF
--- a/internal/daas/machine_catalog/machine_config.go
+++ b/internal/daas/machine_catalog/machine_config.go
@@ -168,6 +168,9 @@ func (mc *AzureMachineConfigModel) RefreshProperties(catalog citrixorchestration
 				mc.AzureMasterImage.StorageAccount = types.StringValue(strings.Split(segments[lastIndex-3], ".")[0])
 			} else if strings.EqualFold(resourceType, util.ImageVersionResourceType) {
 				// Gallery image
+				if mc.AzureMasterImage.GalleryImage == nil {
+					mc.AzureMasterImage.GalleryImage = &GalleryImageModel{}
+				}
 				mc.AzureMasterImage.GalleryImage.Definition = types.StringValue(strings.Split(segments[lastIndex-2], ".")[0])
 				mc.AzureMasterImage.GalleryImage.Gallery = types.StringValue(strings.Split(segments[lastIndex-3], ".")[0])
 			}

--- a/scripts/onboarding-helper/terraform-onboarding.ps1
+++ b/scripts/onboarding-helper/terraform-onboarding.ps1
@@ -190,7 +190,6 @@ function Start-GetRequest {
     }
     
     $contentType = 'application/json'
-    # $response = Invoke-WebRequest -Method GET -Uri $url -Headers $headers -ContentType $contentType
     $response = Invoke-WebRequestWithRetry -Uri $url -Method 'GET' -Headers $headers -ContentType $contentType
     $jsonObj = ConvertFrom-Json $([String]::new($response.Content))
     return $jsonObj
@@ -219,7 +218,7 @@ provider "citrix" {
         $config = @"
 provider "citrix" {
     customer_id                 = "$script:customerId"
-    client_id                   = "$script:domainFqdn\\$script:clientId"
+    client_id                   = "$script:clientId"
     client_secret               = "$script:clientSecret"
     hostname                    = "$script:hostname"
     environment                 = "$script:environment"
@@ -266,6 +265,12 @@ function Get-ResourceList {
     $resourceList = @()
     $pathMap = @{}
     foreach ($item in $items) {
+
+        # Handle special case for Machine Catalogs
+        if ($requestPath -eq "machinecatalogs" -and $item.provisioningType -ne "Manual" -and $item.provisioningType -ne "MCS") {
+            Write-Warning "Currently the citrix terraform provider only supports Manual and MCS Machine Catalogs. Ignoring the Machine Catalog with Name: $($item.name) and Type: $($item.provisioningType)"
+            continue;
+        }
 
         # Handle special case for hypervisors
         if ($requestPath -eq "hypervisors") {

--- a/scripts/onboarding-helper/terraform.tf
+++ b/scripts/onboarding-helper/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     citrix = {
       source  = "citrix/citrix"
-      version = ">=0.5.2"
+      version = ">=0.5.5"
     }
   }
 


### PR DESCRIPTION
- Fix onboarding script to only import catalogs that use Manual or MCS provisioning type. #63 
- Fix a null pointer issue for Azure Gallery Image when importing Azure MCS Machine Catalog.