### PR TITLE
Fix for issue #74 and support for template spec semantic versioning

### DIFF
--- a/internal/daas/machine_catalog/machine_config.go
+++ b/internal/daas/machine_catalog/machine_config.go
@@ -219,7 +219,9 @@ func (mc *AzureMachineConfigModel) RefreshProperties(catalog citrixorchestration
 	for _, stringPair := range customProperties {
 		switch stringPair.GetName() {
 		case "StorageType":
-			mc.StorageType = types.StringValue(stringPair.GetValue())
+			if mc.StorageType != types.StringValue(util.AzureEphemeralOSDisk) {
+				mc.StorageType = types.StringValue(stringPair.GetValue())
+			}
 		case "UseManagedDisks":
 			mc.UseManagedDisks = util.StringToTypeBool(stringPair.GetValue())
 		case "ResourceGroups":
@@ -471,8 +473,7 @@ func parseAzureMachineProfileResponseToModel(machineProfileResponse citrixorches
 	if machineProfileName := machineProfileResponse.GetName(); machineProfileName != "" {
 		machineProfileSegments := strings.Split(machineProfileResponse.GetXDPath(), "\\")
 		lastIndex := len(machineProfileSegments) - 1
-		resourceType := strings.Split(machineProfileSegments[lastIndex], ".")[1]
-		if strings.EqualFold(resourceType, "templatespecversion") {
+		if strings.HasSuffix(machineProfileSegments[lastIndex], ".templatespecversion") {
 			machineProfileModel.MachineProfileTemplateSpecVersion = types.StringValue(machineProfileName)
 
 			templateSpecIndex := slices.IndexFunc(machineProfileSegments, func(machineProfileSegment string) bool {


### PR DESCRIPTION
Regarding the use of semantic versioning (e.g., 1.0.0) for the value of `machine_profile_template_spec_version`, the expression `resourceType := strings.Split(machineProfileSegments[lastIndex], ".")[1]` returned the MINOR version number. Consequently, this result does not evaluate to 'templatespecversion'.