### PR TITLE
Machine Catalog Update restrictions

### DIFF
--- a/internal/daas/machine_catalog/machine_catalog_resource_model.go
+++ b/internal/daas/machine_catalog/machine_catalog_resource_model.go
@@ -325,6 +325,9 @@ func (MachineDomainIdentityModel) GetSchema() schema.SingleNestedAttribute {
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(regexp.MustCompile(util.DomainFqdnRegex), "must be in FQDN format"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"domain_ou": schema.StringAttribute{
 				Description: "The organization unit that computer accounts will be created into.",


### PR DESCRIPTION
**Bugfixes:**

- Restrict updating `citrix_machine_catalog.provisioning_scheme.machine_account_creation_rules` and `citrix_machine_catalog.provisioning_scheme.machine_domain_identity` when no machines are being added.