### PR TITLE
release-v1.0.20

### DIFF
--- a/.github/workflows/gotest-cloud-eu.yml
+++ b/.github/workflows/gotest-cloud-eu.yml
@@ -49,7 +49,7 @@ jobs:
               -ClientSecret ${{secrets.CITRIX_CLIENT_SECRET}} `
               -DomainFqdn ${{secrets.DOMAIN_FQDN}} `
               -CitrixCloudHostname ${{secrets.CITRIX_CLOUD_HOSTNAME}} `
-              -Hostname ${{secrets.HOSTNAME}} `
+              -Hostname ${{secrets.CITRIX_HOSTNAME}} `
               -AzureClientId ${{secrets.AZURE_CLIENT_ID}} `
               -AzureClientSecret ${{secrets.AZURE_CLIENT_SECRET}} `
               -AzureTenantId ${{secrets.AZURE_TENANT_ID}} `

--- a/README.md
+++ b/README.md
@@ -194,12 +194,28 @@ A machine catalog is a collection of machines managed as a single entity. Refer 
 A delivery group is a collection of machines selected from one or more machine catalogs. The delivery group can also specify which users can use those machines, plus the applications and desktops available to those users. Refer the [DaaS Delivery Group documentation](docs/resources/delivery_group.md) to configure a delivery group via terraform.
 
 ### Roadmap Proposal for a Smoother Onboarding Experience
-To streamline your onboarding experience with the Citrix Terraform Provider, we recommend starting with the core resources essential for a Citrix deployment:
+To streamline your onboarding experience with the Citrix Terraform Provider, we recommend to start small by importing or creating one or two resources and build out from there.
 
-- Resource Location (for Citrix Cloud customers only)
-- Zone
-- Hypervisor
-- Hypervisor Resource Pool
+#### Import Your Existing Resources Using the Onboarding Script
+Use our [Onboarding Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/onboarding-helper/) with the following parameters to import existing resources and create Terraform configuration files for them.
+
+- Use the `-ResourceTypes` parameter to specify just a few resource types (for example `citrix_zone`, `citrix_delivery_group`)
+- Use the `-NamesOrIds` parameter to filter for specific resources by name or ID
+
+Example:
+```powershell
+.\terraform-onboarding.ps1 CustomerId "{CustomerId}" -ClientId "{ClientId}" -ClientSecret "{ClientSecret}" -ResourceTypes "citrix_zone","citrix_delivery_group" -NamesOrIds "Primary Zone","Sales Delivery Group"
+```
+
+This incremental approach allows you to become familiar with Terraform concepts and the Citrix provider while working with a smaller, more focused set of resources.
+
+#### Manual Configuration
+Alternatively, we recommend starting by creating new `.tf` files for the core resources essential for a Citrix deployment:
+
+- [citrix_cloud_resource_location](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/cloud_resource_location) (for Citrix Cloud customers only)
+- [citrix_zone](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/zone)
+- citrix_{hosting provider}_hypervisor
+- citrix_{hosting provider}_hypervisor_resource_pool
 
 These resources are straightforward to configure and can be created or removed quickly. Begin your Terraform journey with these resources to build confidence in managing your Citrix deployment via Terraform.
 
@@ -225,25 +241,25 @@ QuickCreate service allows customers to create and manage Amazon WorkSpaces Core
 
 ### What resource is supported for different connection types?
 
-| Connection Type                         |   Hypervisor       |   Resource Pool          |  MCS Power Managed         | MCS Provisioning           |          PVS             | Manual/Remote PC     |
-|-----------------------------------------|--------------------|--------------------------|----------------------------|----------------------------|--------------------------|----------------------|
-| AzureRM                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_check_mark:        | :heavy_check_mark:   |
-| AWS EC2                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| GCP                                     |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| vSphere                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| XenServer                               |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| Nutanix                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| SCVMM                                   |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| Red Hat OpenShift (**Techpreview**)     |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| HPE Moonshot (**Techpreview**)          |:heavy_check_mark:  |:heavy_multiplication_x:  | :heavy_check_mark:         | :heavy_multiplication_x:   |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| Remote PC Wake On LAN (**Techpreview**) |:heavy_check_mark:  |:heavy_multiplication_x:  | :heavy_multiplication_x:   | :heavy_multiplication_x:   |:heavy_multiplication_x:  | :heavy_check_mark:   |
+| Connection Type                         |   Hypervisor       |   Resource Pool    |  MCS Power Managed | MCS Provisioning   |         PVS        | Manual/Remote PC     |
+|-----------------------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|----------------------|
+| AzureRM                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   |
+| AWS EC2                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| GCP                                     |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| vSphere                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| XenServer                               |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| Nutanix                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| SCVMM                                   |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| Red Hat OpenShift (**Techpreview**)     |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| HPE Moonshot (**Techpreview**)          |:heavy_check_mark:  | N/A                | :heavy_check_mark: | N/A                | N/A                | :heavy_check_mark:   |
+| Remote PC Wake On LAN (**Techpreview**) |:heavy_check_mark:  | N/A                | N/A                | N/A                | N/A                | :heavy_check_mark:   |
 
 ### What URLs should be whitelisted in order to use the Citrix Terraform provider?
 - URLs of the Citrix admin consoles: please visit [this documentation](https://docs.citrix.com/en-us/citrix-cloud/overview/requirements/internet-connectivity-requirements.html) for more information.
 - URL of the HashiCorp Terraform registry: https://registry.terraform.io or a private registry.
 
 ### How do I get the ID to import a DaaS resource?
-The [Onboarding Script](scripts/onboarding-helper/) will discover all resource IDs and import them into a local terraform state file. You can then run `terraform state show` to inspect the state and discover the IDs.
+The [Object IDs Helper Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/object-ids-helper/) will discover all resource IDs and save them to a JSON file for easy reference.
 
 Alternatively the IDs can be found in Web Studio by looking at the network traces. Open your browser developer tools (usually F12) and navigate to the `Network` tab. Refresh Web Studio and click on the resource you want to find the ID for. There should be 2 corresponding network calls (`OPTIONS` then `GET`) for the resource which includes the ID as the last path in the url before the `?` query.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,33 @@ Check out the [release notes](https://github.com/citrix/terraform-provider-citri
 
 New to Terraform? Click [here](https://developer.hashicorp.com/terraform) to learn more.
 
-### Importing existing Citrix resources into Terraform
+### Roadmap Proposal for a Smoother Onboarding Experience
+To streamline your onboarding experience with the Citrix Terraform Provider, we recommend to start small by importing or creating one or two resources and build out from there.
 
-Experience the immediate benefits of Terraform by importing your Citrix resources (CVAD or DaaS) using our [Onboarding Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/onboarding-helper/terraform-onboarding.ps1). This allows you to quickly adopt infrastructure as code and streamline your infrastructure management. A comprehensive [ReadMe](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/onboarding-helper/README.md) is available to guide you through the process.
+#### Import Your Existing Resources Using the Onboarding Script
+Use our [Onboarding Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/onboarding-helper/) with the following parameters to import existing resources and create Terraform configuration files for them.
+
+- Use the `-ResourceTypes` parameter to specify just a few resource types (for example `citrix_zone`, `citrix_delivery_group`)
+- Use the `-NamesOrIds` parameter to filter for specific resources by name or ID
+
+Example:
+```powershell
+.\terraform-onboarding.ps1 CustomerId "{CustomerId}" -ClientId "{ClientId}" -ClientSecret "{ClientSecret}" -ResourceTypes "citrix_zone","citrix_delivery_group" -NamesOrIds "Primary Zone","Sales Delivery Group"
+```
+
+This incremental approach allows you to become familiar with Terraform concepts and the Citrix provider while working with a smaller, more focused set of resources.
+
+#### Manual Configuration
+Alternatively, we recommend starting by creating new `.tf` files for the core resources essential for a Citrix deployment:
+
+- [citrix_cloud_resource_location](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/cloud_resource_location) (for Citrix Cloud customers only)
+- [citrix_zone](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/zone)
+- citrix_{hosting provider}_hypervisor
+- citrix_{hosting provider}_hypervisor_resource_pool
+
+These resources are straightforward to configure and can be created or removed quickly. Begin your Terraform journey with these resources to build confidence in managing your Citrix deployment via Terraform.
+
+Once these resources are properly configured, the next step is to set up your [machine catalog](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/machine_catalog) with Terraform. Managing the machine catalog with Terraform will provide a solid foundation for designing a pipeline that meets your specific use case.
 
 ### Creating Citrix resources via Terraform
 
@@ -41,18 +65,6 @@ Basic example templates for getting started can be found in our [GitHub reposito
 ### Demo video
 [![alt text](https://raw.githubusercontent.com/citrix/terraform-provider-citrix/refs/heads/main/images/techzone-youtube-thumbnail.png)](https://www.youtube.com/watch?v=c33sMLaCVjY)
 https://www.youtube.com/watch?v=c33sMLaCVjY
-
-### Roadmap Proposal for a Smoother Onboarding Experience
-To streamline your onboarding experience with the Citrix Terraform Provider, we recommend starting with the core resources essential for a Citrix deployment:
-
-- Resource Location (for Citrix Cloud customers only)
-- Zone
-- Hypervisor
-- Hypervisor Resource Pool
-
-These resources are straightforward to configure and can be created or removed quickly. Begin your Terraform journey with these resources to build confidence in managing your Citrix deployment via Terraform.
-
-Once these resources are properly configured, the next step is to set up your [machine catalog](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/machine_catalog) with Terraform. Managing the machine catalog with Terraform will provide a solid foundation for designing a pipeline that meets your specific use case.
 
 ### (On-Premises Only) Enable Web Studio
 
@@ -91,7 +103,7 @@ A service principal is an API client which is not associated with an email. It c
 - URL of the HashiCorp Terraform registry: https://registry.terraform.io or a private registry.
 
 ### How do I get the ID to import a DaaS resource?
-The [Onboarding Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/onboarding-helper/) will discover all resource IDs and import them into a local terraform state file. You can then run `terraform state show` to inspect the state and discover the IDs.
+The [Object IDs Helper Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/object-ids-helper/) will discover all resource IDs and save them to a JSON file for easy reference.
 
 Alternatively the IDs can be found in Web Studio by looking at the network traces. Open your browser developer tools (usually F12) and navigate to the `Network` tab. Refresh Web Studio and click on the resource you want to find the ID for. There should be 2 corresponding network calls (`OPTIONS` then `GET`) for the resource which includes the ID as the last path in the url before the `?` query.
 

--- a/internal/citrixcloud/admin_user/admin_user_resource_model.go
+++ b/internal/citrixcloud/admin_user/admin_user_resource_model.go
@@ -196,6 +196,17 @@ func (CCAdminUserResourceModel) GetAttributes() map[string]schema.Attribute {
 	return CCAdminUserResourceModel{}.GetSchema().Attributes
 }
 
+func (CCAdminUserResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"admin_id":         true,
+		"display_name":     true,
+		"email":            true,
+		"first_name":       true,
+		"last_name":        true,
+		"external_user_id": true,
+	}
+}
+
 func (r CCAdminUserResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, adminUser ccadmins.AdministratorResult) CCAdminUserResourceModel {
 	r.AccessType = types.StringValue(string(adminUser.GetAccessType()))
 	r.Type = types.StringValue(string(adminUser.GetType()))

--- a/internal/citrixcloud/global_app_configuration/gac_discovery_resource_model.go
+++ b/internal/citrixcloud/global_app_configuration/gac_discovery_resource_model.go
@@ -57,6 +57,10 @@ func (GACDiscoveryResourceModel) GetSchema() schema.Schema {
 	}
 }
 
+func (GACDiscoveryResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r GACDiscoveryResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, discoveryRecordModel globalappconfiguration.DiscoveryRecordModel) GACDiscoveryResourceModel {
 
 	r.Domain = types.StringValue(discoveryRecordModel.Domain.GetName())

--- a/internal/citrixcloud/global_app_configuration/gac_settings_resource_model.go
+++ b/internal/citrixcloud/global_app_configuration/gac_settings_resource_model.go
@@ -38,6 +38,10 @@ func (GACSettingsResourceModel) GetAttributes() map[string]schema.Attribute {
 	return GACSettingsResourceModel{}.GetSchema().Attributes
 }
 
+func (GACSettingsResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 type AppSettings struct {
 	Windows  types.Set `tfsdk:"windows"`  //Set[Windows]
 	Ios      types.Set `tfsdk:"ios"`      //Set[Ios]

--- a/internal/citrixcloud/identity_providers/google_identity_provider_resource_model.go
+++ b/internal/citrixcloud/identity_providers/google_identity_provider_resource_model.go
@@ -94,6 +94,13 @@ func (GoogleIdentityProviderResourceModel) GetAttributes() map[string]schema.Att
 	return GoogleIdentityProviderResourceModel{}.GetSchema().Attributes
 }
 
+func (GoogleIdentityProviderResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"client_email":       true,
+		"google_customer_id": true,
+	}
+}
+
 func (r GoogleIdentityProviderResourceModel) RefreshIdAndNameValues(googleIdp *citrixcws.IdpStatusModel) GoogleIdentityProviderResourceModel {
 	r.Id = types.StringValue(googleIdp.GetIdpInstanceId())
 	r.Name = types.StringValue(googleIdp.GetIdpNickname())

--- a/internal/citrixcloud/identity_providers/okta_identity_provider_resource_model.go
+++ b/internal/citrixcloud/identity_providers/okta_identity_provider_resource_model.go
@@ -83,6 +83,12 @@ func (OktaIdentityProviderModel) GetAttributes() map[string]schema.Attribute {
 	return OktaIdentityProviderModel{}.GetSchema().Attributes
 }
 
+func (OktaIdentityProviderModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"okta_client_id": true,
+	}
+}
+
 func (r OktaIdentityProviderModel) RefreshPropertyValues(isResource bool, oktaIdp *citrixcws.IdpStatusModel) OktaIdentityProviderModel {
 
 	// Overwrite Okta Identity Provider Resource with refreshed state

--- a/internal/citrixcloud/identity_providers/saml_identity_provider_resource_model.go
+++ b/internal/citrixcloud/identity_providers/saml_identity_provider_resource_model.go
@@ -109,6 +109,10 @@ func (SamlAttributeNameMappings) GetAttributes() map[string]schema.Attribute {
 	return SamlAttributeNameMappings{}.GetSchema().Attributes
 }
 
+func (SamlIdentityProviderModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 type SamlIdentityProviderModel struct {
 	Id             types.String `tfsdk:"id"`
 	Name           types.String `tfsdk:"name"`

--- a/internal/citrixcloud/resource_locations/resource_locations_resource_model.go
+++ b/internal/citrixcloud/resource_locations/resource_locations_resource_model.go
@@ -59,6 +59,10 @@ func (ResourceLocationModel) GetAttributes() map[string]schema.Attribute {
 	return ResourceLocationModel{}.GetSchema().Attributes
 }
 
+func (ResourceLocationModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r ResourceLocationModel) RefreshPropertyValues(ccResourceLocation *ccresourcelocations.CitrixCloudServicesRegistryApiModelsLocationsResourceLocationModel) ResourceLocationModel {
 
 	// Overwrite resource location with refreshed state

--- a/internal/daas/admin_folder/admin_folder_resource_model.go
+++ b/internal/daas/admin_folder/admin_folder_resource_model.go
@@ -99,6 +99,10 @@ func (AdminFolderModel) GetAttributes() map[string]schema.Attribute {
 	return AdminFolderModel{}.GetSchema().Attributes
 }
 
+func (AdminFolderModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r AdminFolderModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, adminFolder *citrixorchestration.AdminFolderResponseModel) AdminFolderModel {
 	// Overwrite application folder with refreshed state
 	r.Id = types.StringValue(adminFolder.GetId())

--- a/internal/daas/admin_role/admin_role_resource_model.go
+++ b/internal/daas/admin_role/admin_role_resource_model.go
@@ -110,3 +110,7 @@ func (AdminRoleModel) GetSchema() schema.Schema {
 func (AdminRoleModel) GetAttributes() map[string]schema.Attribute {
 	return AdminRoleModel{}.GetSchema().Attributes
 }
+
+func (AdminRoleModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}

--- a/internal/daas/admin_scope/admin_scope_resource_model.go
+++ b/internal/daas/admin_scope/admin_scope_resource_model.go
@@ -99,3 +99,7 @@ func (AdminScopeModel) GetSchema() schema.Schema {
 func (AdminScopeModel) GetAttributes() map[string]schema.Attribute {
 	return AdminScopeModel{}.GetSchema().Attributes
 }
+
+func (AdminScopeModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}

--- a/internal/daas/admin_user/admin_user_resource_model.go
+++ b/internal/daas/admin_user/admin_user_resource_model.go
@@ -159,3 +159,9 @@ func (AdminUserResourceModel) GetSchema() schema.Schema {
 func (AdminUserResourceModel) GetAttributes() map[string]schema.Attribute {
 	return AdminUserResourceModel{}.GetSchema().Attributes
 }
+
+func (AdminUserResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"name": true,
+	}
+}

--- a/internal/daas/application/application_group_resource_model.go
+++ b/internal/daas/application/application_group_resource_model.go
@@ -158,6 +158,12 @@ func (ApplicationGroupResourceModel) GetSchema() schema.Schema {
 	}
 }
 
+func (ApplicationGroupResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"included_users": true,
+	}
+}
+
 func (ApplicationGroupResourceModel) GetAttributes() map[string]schema.Attribute {
 	return ApplicationGroupResourceModel{}.GetSchema().Attributes
 }

--- a/internal/daas/application/application_icon_resource_model.go
+++ b/internal/daas/application/application_icon_resource_model.go
@@ -63,6 +63,10 @@ func (ApplicationIconResourceModel) GetAttributes() map[string]schema.Attribute 
 	return ApplicationIconResourceModel{}.GetSchema().Attributes
 }
 
+func (ApplicationIconResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r ApplicationIconResourceModel) RefreshPropertyValues(application *citrixorchestration.IconResponseModel) ApplicationIconResourceModel {
 	// Overwrite application folder with refreshed state
 	r.Id = types.StringValue(application.GetId())

--- a/internal/daas/application/application_resource_model.go
+++ b/internal/daas/application/application_resource_model.go
@@ -336,6 +336,12 @@ func (ApplicationResourceModel) GetAttributes() map[string]schema.Attribute {
 	return ApplicationResourceModel{}.GetSchema().Attributes
 }
 
+func (ApplicationResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"limit_visibility_to_users": true,
+	}
+}
+
 func (r ApplicationResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, application *citrixorchestration.ApplicationDetailResponseModel, applicationGroups *citrixorchestration.ApplicationGroupResponseModelCollection, applicationDeliveryGroups *citrixorchestration.ApplicationDeliveryGroupResponseModelCollection, tags []string) ApplicationResourceModel {
 	// Overwrite application with refreshed state
 	r.Id = types.StringValue(application.GetId())

--- a/internal/daas/cvad_site/site_settings_resource_model.go
+++ b/internal/daas/cvad_site/site_settings_resource_model.go
@@ -104,6 +104,10 @@ func (SiteSettingsModel) GetAttributes() map[string]schema.Attribute {
 	return SiteSettingsModel{}.GetSchema().Attributes
 }
 
+func (SiteSettingsModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r SiteSettingsModel) RefreshResourcePropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, client *citrixdaasclient.CitrixDaasClient, siteSettingsResponse *citrixorchestration.SiteSettingsResponseModel, multipleRemotePcAssignments bool) SiteSettingsModel {
 	r.SiteId = types.StringValue(client.ClientConfig.SiteId)
 	if !r.WebUiPolicySetEnabled.IsNull() {

--- a/internal/daas/delivery_group/delivery_group_resource_model.go
+++ b/internal/daas/delivery_group/delivery_group_resource_model.go
@@ -1380,6 +1380,14 @@ func (DeliveryGroupResourceModel) GetSchema() schema.Schema {
 	}
 }
 
+func (DeliveryGroupResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"allow_list": true,
+		"block_list": true,
+		"users":      true,
+	}
+}
+
 func (DeliveryGroupResourceModel) GetAttributes() map[string]schema.Attribute {
 	return DeliveryGroupResourceModel{}.GetSchema().Attributes
 }

--- a/internal/daas/desktop_icon/desktop_icon_resource_model.go
+++ b/internal/daas/desktop_icon/desktop_icon_resource_model.go
@@ -63,6 +63,10 @@ func (DesktopIconResourceModel) GetAttributes() map[string]schema.Attribute {
 	return DesktopIconResourceModel{}.GetSchema().Attributes
 }
 
+func (DesktopIconResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r DesktopIconResourceModel) RefreshPropertyValues(desktop *citrixorchestration.IconResponseModel) DesktopIconResourceModel {
 	// Overwrite desktop folder with refreshed state
 	r.Id = types.StringValue(desktop.GetId())

--- a/internal/daas/hypervisor/aws_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/aws_hypervisor_resource_model.go
@@ -105,6 +105,12 @@ func (AwsHypervisorResourceModel) GetAttributes() map[string]schema.Attribute {
 	return AwsHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (AwsHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"api_key": true,
+	}
+}
+
 func (r AwsHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) AwsHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor/azure_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/azure_hypervisor_resource_model.go
@@ -151,6 +151,12 @@ func (AzureHypervisorResourceModel) GetAttributes() map[string]schema.Attribute 
 	return AzureHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (AzureHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"application_id": true,
+	}
+}
+
 func (r AzureHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) AzureHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor/gcp_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/gcp_hypervisor_resource_model.go
@@ -97,6 +97,12 @@ func (GcpHypervisorResourceModel) GetAttributes() map[string]schema.Attribute {
 	return GcpHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (GcpHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"service_account_id": true,
+	}
+}
+
 func (r GcpHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) GcpHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor/hpe_moonshot_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/hpe_moonshot_hypervisor_resource_model.go
@@ -171,6 +171,12 @@ func (HpeMoonshotHypervisorResourceModel) GetAttributes() map[string]schema.Attr
 	return HpeMoonshotHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (HpeMoonshotHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"username": true,
+	}
+}
+
 func (r HpeMoonshotHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) HpeMoonshotHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor/nutanix_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/nutanix_hypervisor_resource_model.go
@@ -149,6 +149,12 @@ func (NutanixHypervisorResourceModel) GetAttributes() map[string]schema.Attribut
 	return NutanixHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (NutanixHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"username": true,
+	}
+}
+
 func (r NutanixHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) NutanixHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor/openshift_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/openshift_hypervisor_resource_model.go
@@ -151,6 +151,10 @@ func (OpenShiftHypervisorResourceModel) GetAttributes() map[string]schema.Attrib
 	return OpenShiftHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (OpenShiftHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r OpenShiftHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) OpenShiftHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor/remotepc_wake_on_lan_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/remotepc_wake_on_lan_hypervisor_resource_model.go
@@ -111,6 +111,10 @@ func (RemotePCWakeOnLANHypervisorResourceModel) GetAttributes() map[string]schem
 	return RemotePCWakeOnLANHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (RemotePCWakeOnLANHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r RemotePCWakeOnLANHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) RemotePCWakeOnLANHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor/scvmm_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/scvmm_hypervisor_resource_model.go
@@ -147,6 +147,12 @@ func (SCVMMMHypervisorResourceModel) GetAttributes() map[string]schema.Attribute
 	return SCVMMMHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (SCVMMMHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"username": true,
+	}
+}
+
 func (r SCVMMMHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) SCVMMMHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor/vsphere_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/vsphere_hypervisor_resource_model.go
@@ -165,6 +165,12 @@ func (VsphereHypervisorResourceModel) GetAttributes() map[string]schema.Attribut
 	return VsphereHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (VsphereHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"username": true,
+	}
+}
+
 func (r VsphereHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) VsphereHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor/xenserver_hypervisor_resource_model.go
+++ b/internal/daas/hypervisor/xenserver_hypervisor_resource_model.go
@@ -168,6 +168,12 @@ func (XenserverHypervisorResourceModel) GetAttributes() map[string]schema.Attrib
 	return XenserverHypervisorResourceModel{}.GetSchema().Attributes
 }
 
+func (XenserverHypervisorResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"username": true,
+	}
+}
+
 func (r XenserverHypervisorResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, hypervisor *citrixorchestration.HypervisorDetailResponseModel) XenserverHypervisorResourceModel {
 	r.Id = types.StringValue(hypervisor.GetId())
 	r.Name = types.StringValue(hypervisor.GetName())

--- a/internal/daas/hypervisor_resource_pool/aws_hypervisor_resource_pool_resource_model.go
+++ b/internal/daas/hypervisor_resource_pool/aws_hypervisor_resource_pool_resource_model.go
@@ -95,6 +95,10 @@ func (AwsHypervisorResourcePoolResourceModel) GetAttributes() map[string]schema.
 	return AwsHypervisorResourcePoolResourceModel{}.GetSchema().Attributes
 }
 
+func (AwsHypervisorResourcePoolResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r AwsHypervisorResourcePoolResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, resourcePool *citrixorchestration.HypervisorResourcePoolDetailResponseModel) AwsHypervisorResourcePoolResourceModel {
 
 	r.Id = types.StringValue(resourcePool.GetId())

--- a/internal/daas/hypervisor_resource_pool/azure_hypervisor_resource_pool_resource_model.go
+++ b/internal/daas/hypervisor_resource_pool/azure_hypervisor_resource_pool_resource_model.go
@@ -111,6 +111,10 @@ func (AzureHypervisorResourcePoolResourceModel) GetAttributes() map[string]schem
 	return AzureHypervisorResourcePoolResourceModel{}.GetSchema().Attributes
 }
 
+func (AzureHypervisorResourcePoolResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r AzureHypervisorResourcePoolResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, resourcePool *citrixorchestration.HypervisorResourcePoolDetailResponseModel) AzureHypervisorResourcePoolResourceModel {
 
 	r.Id = types.StringValue(resourcePool.GetId())

--- a/internal/daas/hypervisor_resource_pool/gcp_hypervisor_resource_pool_resource_model.go
+++ b/internal/daas/hypervisor_resource_pool/gcp_hypervisor_resource_pool_resource_model.go
@@ -120,6 +120,10 @@ func (GcpHypervisorResourcePoolResourceModel) GetAttributes() map[string]schema.
 	return GcpHypervisorResourcePoolResourceModel{}.GetSchema().Attributes
 }
 
+func (GcpHypervisorResourcePoolResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r GcpHypervisorResourcePoolResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, resourcePool *citrixorchestration.HypervisorResourcePoolDetailResponseModel) GcpHypervisorResourcePoolResourceModel {
 
 	r.Id = types.StringValue(resourcePool.GetId())

--- a/internal/daas/hypervisor_resource_pool/nutanix_hypervisor_resource_pool_resource_model.go
+++ b/internal/daas/hypervisor_resource_pool/nutanix_hypervisor_resource_pool_resource_model.go
@@ -77,6 +77,10 @@ func (NutanixHypervisorResourcePoolResourceModel) GetAttributes() map[string]sch
 	return NutanixHypervisorResourcePoolResourceModel{}.GetSchema().Attributes
 }
 
+func (NutanixHypervisorResourcePoolResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r NutanixHypervisorResourcePoolResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, resourcePool *citrixorchestration.HypervisorResourcePoolDetailResponseModel) NutanixHypervisorResourcePoolResourceModel {
 
 	r.Id = types.StringValue(resourcePool.GetId())

--- a/internal/daas/hypervisor_resource_pool/openshift_hypervisor_resource_pool_resource_model.go
+++ b/internal/daas/hypervisor_resource_pool/openshift_hypervisor_resource_pool_resource_model.go
@@ -93,6 +93,10 @@ func (OpenShiftHypervisorResourcePoolResourceModel) GetAttributes() map[string]s
 	return OpenShiftHypervisorResourcePoolResourceModel{}.GetSchema().Attributes
 }
 
+func (OpenShiftHypervisorResourcePoolResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r OpenShiftHypervisorResourcePoolResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, resourcePool *citrixorchestration.HypervisorResourcePoolDetailResponseModel) OpenShiftHypervisorResourcePoolResourceModel {
 
 	r.Id = types.StringValue(resourcePool.GetId())

--- a/internal/daas/hypervisor_resource_pool/scvmm_hypervisor_resource_pool_resource_model.go
+++ b/internal/daas/hypervisor_resource_pool/scvmm_hypervisor_resource_pool_resource_model.go
@@ -120,6 +120,10 @@ func (SCVMMHypervisorResourcePoolResourceModel) GetAttributes() map[string]schem
 	return SCVMMHypervisorResourcePoolResourceModel{}.GetSchema().Attributes
 }
 
+func (SCVMMHypervisorResourcePoolResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r SCVMMHypervisorResourcePoolResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, resourcePool *citrixorchestration.HypervisorResourcePoolDetailResponseModel) SCVMMHypervisorResourcePoolResourceModel {
 
 	r.Id = types.StringValue(resourcePool.GetId())

--- a/internal/daas/hypervisor_resource_pool/vsphere_hypervisor_resource_pool_resource_model.go
+++ b/internal/daas/hypervisor_resource_pool/vsphere_hypervisor_resource_pool_resource_model.go
@@ -146,6 +146,10 @@ func (VsphereHypervisorResourcePoolResourceModel) GetAttributes() map[string]sch
 	return VsphereHypervisorResourcePoolResourceModel{}.GetSchema().Attributes
 }
 
+func (VsphereHypervisorResourcePoolResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r VsphereHypervisorResourcePoolResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, resourcePool *citrixorchestration.HypervisorResourcePoolDetailResponseModel) VsphereHypervisorResourcePoolResourceModel {
 
 	r.Id = types.StringValue(resourcePool.GetId())

--- a/internal/daas/hypervisor_resource_pool/xenserver_hypervisor_resource_pool_resource_model.go
+++ b/internal/daas/hypervisor_resource_pool/xenserver_hypervisor_resource_pool_resource_model.go
@@ -106,6 +106,10 @@ func (XenserverHypervisorResourcePoolResourceModel) GetAttributes() map[string]s
 	return XenserverHypervisorResourcePoolResourceModel{}.GetSchema().Attributes
 }
 
+func (XenserverHypervisorResourcePoolResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r XenserverHypervisorResourcePoolResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, resourcePool *citrixorchestration.HypervisorResourcePoolDetailResponseModel) XenserverHypervisorResourcePoolResourceModel {
 
 	r.Id = types.StringValue(resourcePool.GetId())

--- a/internal/daas/image_definition/image_definition_resource_model.go
+++ b/internal/daas/image_definition/image_definition_resource_model.go
@@ -156,6 +156,10 @@ func (ImageDefinitionModel) GetAttributes() map[string]schema.Attribute {
 	return ImageDefinitionModel{}.GetSchema().Attributes
 }
 
+func (ImageDefinitionModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 type ImageDefinitionTimeout struct {
 	Create types.Int32 `tfsdk:"create"`
 	Delete types.Int32 `tfsdk:"delete"`

--- a/internal/daas/image_definition/image_version_resource_model.go
+++ b/internal/daas/image_definition/image_version_resource_model.go
@@ -202,6 +202,10 @@ func (ImageVersionModel) GetAttributes() map[string]schema.Attribute {
 	return ImageVersionModel{}.GetSchema().Attributes
 }
 
+func (ImageVersionModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 type ImageVersionTimeout struct {
 	Create types.Int32 `tfsdk:"create"`
 	Delete types.Int32 `tfsdk:"delete"`

--- a/internal/daas/machine_catalog/machine_catalog_resource_model.go
+++ b/internal/daas/machine_catalog/machine_catalog_resource_model.go
@@ -32,6 +32,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func (MachineCatalogResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"ad_account_name":    true,
+		"service_account_id": true,
+		"service_account":    true,
+	}
+}
+
 // MachineCatalogResourceModel maps the resource schema data.
 type MachineCatalogResourceModel struct {
 	Id                       types.String `tfsdk:"id"`

--- a/internal/daas/machine_catalog/machine_properties_resource_model.go
+++ b/internal/daas/machine_catalog/machine_properties_resource_model.go
@@ -67,6 +67,10 @@ func (MachinePropertiesModel) GetAttributes() map[string]schema.Attribute {
 	return MachinePropertiesModel{}.GetSchema().Attributes
 }
 
+func (MachinePropertiesModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r MachinePropertiesModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, machine *citrixorchestration.MachineDetailResponseModel, tagIds []string) MachinePropertiesModel {
 	machineName := strings.ToLower(machine.GetName())
 	r.Name = types.StringValue(machineName)

--- a/internal/daas/policies/policy_set_resource_model.go
+++ b/internal/daas/policies/policy_set_resource_model.go
@@ -64,6 +64,13 @@ func (PolicySettingModel) GetAttributes() map[string]schema.Attribute {
 	return PolicySettingModel{}.GetSchema().Attributes
 }
 
+func (PolicySetModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"client_name": true,
+		"sid":         true,
+	}
+}
+
 type PolicyModel struct {
 	Id                       types.String `tfsdk:"id"`
 	Name                     types.String `tfsdk:"name"`

--- a/internal/daas/policy_filters/access_control_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/access_control_policy_filter_resource_model.go
@@ -82,6 +82,10 @@ func (AccessControlFilterModel) GetAttributes() map[string]schema.Attribute {
 	return AccessControlFilterModel{}.GetSchema().Attributes
 }
 
+func (AccessControlFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (filter AccessControlFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_filters/branch_repeater_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/branch_repeater_policy_filter_resource_model.go
@@ -56,6 +56,10 @@ func (BranchRepeaterFilterModel) GetAttributes() map[string]schema.Attribute {
 	return BranchRepeaterFilterModel{}.GetSchema().Attributes
 }
 
+func (BranchRepeaterFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (filter BranchRepeaterFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_filters/client_ip_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/client_ip_policy_filter_resource_model.go
@@ -70,6 +70,10 @@ func (ClientIPFilterModel) GetAttributes() map[string]schema.Attribute {
 	return ClientIPFilterModel{}.GetSchema().Attributes
 }
 
+func (ClientIPFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (filter ClientIPFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_filters/client_name_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/client_name_policy_filter_resource_model.go
@@ -66,6 +66,12 @@ func (ClientNameFilterModel) GetAttributes() map[string]schema.Attribute {
 	return ClientNameFilterModel{}.GetSchema().Attributes
 }
 
+func (ClientNameFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"client_name": true,
+	}
+}
+
 func (filter ClientNameFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_filters/client_platform_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/client_platform_policy_filter_resource_model.go
@@ -76,6 +76,10 @@ func (ClientPlatformFilterModel) GetAttributes() map[string]schema.Attribute {
 	return ClientPlatformFilterModel{}.GetSchema().Attributes
 }
 
+func (ClientPlatformFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (filter ClientPlatformFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_filters/delivery_group_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/delivery_group_policy_filter_resource_model.go
@@ -70,6 +70,10 @@ func (DeliveryGroupFilterModel) GetAttributes() map[string]schema.Attribute {
 	return DeliveryGroupFilterModel{}.GetSchema().Attributes
 }
 
+func (DeliveryGroupFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (filter DeliveryGroupFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_filters/delivery_group_type_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/delivery_group_type_policy_filter_resource_model.go
@@ -73,6 +73,10 @@ func (DeliveryGroupTypeFilterModel) GetAttributes() map[string]schema.Attribute 
 	return DeliveryGroupTypeFilterModel{}.GetSchema().Attributes
 }
 
+func (DeliveryGroupTypeFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (filter DeliveryGroupTypeFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_filters/ou_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/ou_policy_filter_resource_model.go
@@ -66,6 +66,10 @@ func (OuFilterModel) GetAttributes() map[string]schema.Attribute {
 	return OuFilterModel{}.GetSchema().Attributes
 }
 
+func (OuFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (filter OuFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_filters/tag_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/tag_policy_filter_resource_model.go
@@ -67,6 +67,10 @@ func (TagFilterModel) GetAttributes() map[string]schema.Attribute {
 	return TagFilterModel{}.GetSchema().Attributes
 }
 
+func (TagFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (filter TagFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_filters/user_policy_filter_resource_model.go
+++ b/internal/daas/policy_filters/user_policy_filter_resource_model.go
@@ -66,6 +66,12 @@ func (UserFilterModel) GetAttributes() map[string]schema.Attribute {
 	return UserFilterModel{}.GetSchema().Attributes
 }
 
+func (UserFilterModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"sid": true,
+	}
+}
+
 func (filter UserFilterModel) GetId() string {
 	return filter.Id.ValueString()
 }

--- a/internal/daas/policy_priority/policy_priority_resource_model.go
+++ b/internal/daas/policy_priority/policy_priority_resource_model.go
@@ -64,6 +64,10 @@ func (PolicyPriorityModel) GetAttributes() map[string]schema.Attribute {
 	return PolicyPriorityModel{}.GetSchema().Attributes
 }
 
+func (PolicyPriorityModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r PolicyPriorityModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, policySet *citrixorchestration.PolicySetResponse, policies *citrixorchestration.CollectionEnvelopeOfPolicyResponse) PolicyPriorityModel {
 	r.PolicySetId = types.StringValue(policySet.GetPolicySetGuid())
 	r.PolicySetName = types.StringValue(policySet.GetName())

--- a/internal/daas/policy_resource/policy_resource_model.go
+++ b/internal/daas/policy_resource/policy_resource_model.go
@@ -67,6 +67,10 @@ func (PolicyModel) GetAttributes() map[string]schema.Attribute {
 	return PolicyModel{}.GetSchema().Attributes
 }
 
+func (PolicyModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r PolicyModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, policy *citrixorchestration.PolicyResponse) PolicyModel {
 	r.Id = types.StringValue(policy.GetPolicyGuid())
 	r.PolicySetId = types.StringValue(policy.GetPolicySetGuid())

--- a/internal/daas/policy_set_resource/policy_set_resource_model_v2.go
+++ b/internal/daas/policy_set_resource/policy_set_resource_model_v2.go
@@ -93,6 +93,10 @@ func (PolicySetV2Model) GetAttributes() map[string]schema.Attribute {
 	return PolicySetV2Model{}.GetSchema().Attributes
 }
 
+func (PolicySetV2Model) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r PolicySetV2Model) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, isDefaultPolicySet bool, policySet *citrixorchestration.PolicySetResponse, policySetScopes []string, deliveryGroups []citrixorchestration.DeliveryGroupResponseModel) PolicySetV2Model {
 	// Set required values
 	r.Id = types.StringValue(policySet.GetPolicySetGuid())

--- a/internal/daas/policy_setting/policy_setting_resource_model.go
+++ b/internal/daas/policy_setting/policy_setting_resource_model.go
@@ -85,6 +85,10 @@ func (PolicySettingModel) GetAttributes() map[string]schema.Attribute {
 	return PolicySettingModel{}.GetSchema().Attributes
 }
 
+func (PolicySettingModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func buildSettingRequest(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diagnostics *diag.Diagnostics, policySetting PolicySettingModel, action string) (citrixorchestration.SettingRequest, error) {
 	settingRequest := citrixorchestration.SettingRequest{}
 	defaultBoolSettingValueMap, err := policies.GetGpoBooleanSettingDefaultValueMap(ctx, diagnostics, client)

--- a/internal/daas/service_account/service_account_resource_model.go
+++ b/internal/daas/service_account/service_account_resource_model.go
@@ -141,6 +141,12 @@ func (ServiceAccountModel) GetAttributes() map[string]schema.Attribute {
 	return ServiceAccountModel{}.GetSchema().Attributes
 }
 
+func (ServiceAccountModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"account_id": true,
+	}
+}
+
 func (r ServiceAccountModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, serviceAccountModel *citrixorchestration.ServiceAccountResponseModel) ServiceAccountModel {
 	r.Id = types.StringValue(serviceAccountModel.GetServiceAccountUid())
 	if !strings.EqualFold(r.DisplayName.ValueString(), serviceAccountModel.GetDisplayName()) {

--- a/internal/daas/site_backup_schedule/site_backup_schedule_resource_model.go
+++ b/internal/daas/site_backup_schedule/site_backup_schedule_resource_model.go
@@ -114,6 +114,10 @@ func (SiteBackupScheduleModel) GetAttributes() map[string]schema.Attribute {
 	return SiteBackupScheduleModel{}.GetSchema().Attributes
 }
 
+func (SiteBackupScheduleModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r SiteBackupScheduleModel) RefreshPropertyValues(backupSchedule *citrixorchestration.BackupRestoreScheduleModel) SiteBackupScheduleModel {
 	r.Id = types.StringValue(strconv.Itoa(int(backupSchedule.GetUid())))
 	r.Name = types.StringValue(backupSchedule.GetName())

--- a/internal/daas/tags/tag_resource_model.go
+++ b/internal/daas/tags/tag_resource_model.go
@@ -99,6 +99,10 @@ func (TagResourceModel) GetAttributes() map[string]schema.Attribute {
 	return TagResourceModel{}.GetSchema().Attributes
 }
 
+func (TagResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r TagResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, client *citrixclient.CitrixDaasClient, tag *citrixorchestration.TagDetailResponseModel) TagResourceModel {
 
 	r.Id = types.StringValue(tag.GetId())

--- a/internal/daas/zone/zone_resource_model.go
+++ b/internal/daas/zone/zone_resource_model.go
@@ -72,6 +72,10 @@ func (ZoneResourceModel) GetAttributes() map[string]schema.Attribute {
 	return ZoneResourceModel{}.GetSchema().Attributes
 }
 
+func (ZoneResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r ZoneResourceModel) RefreshPropertyValues(ctx context.Context, diags *diag.Diagnostics, zone *citrixorchestration.ZoneDetailResponseModel, onpremises bool) ZoneResourceModel {
 	// Overwrite zone with refreshed state
 	r.Id = types.StringValue(zone.GetId())

--- a/internal/examples/resources/citrix_machine_catalog/resource.tf
+++ b/internal/examples/resources/citrix_machine_catalog/resource.tf
@@ -132,6 +132,50 @@ resource "citrix_machine_catalog" "example-aws-mtsession" {
     }	
 }
 
+resource "citrix_machine_catalog" "example-aws-with-machine-profile" {
+    name                        = "example-aws-with-machine-profile"
+    description                 = "Example multi-session catalog on AWS hypervisor"
+   	zone						= "<zone Id>"
+	allocation_type				= "Random"
+	session_support				= "MultiSession"
+	provisioning_type 			= "MCS"
+    provisioning_scheme         = {
+		hypervisor = citrix_aws_hypervisor.example-aws-hypervisor.id
+		hypervisor_resource_pool = citrix_aws_hypervisor_resource_pool.example-aws-hypervisor-resource-pool.id
+		identity_type      = "ActiveDirectory"
+		machine_domain_identity = {
+            domain                   = "<DomainFQDN>"
+			domain_ou				 = "<DomainOU>"
+            service_account          = "<Admin Username>"
+            service_account_password = "<Admin Password>"
+        }
+        aws_machine_config = {
+            image_ami = "<AMI ID for VDA>"
+			master_image = "<Image template AMI name>"
+			service_offering = "t2.small"
+            # Cannot provide security groups if you provide machine profile. Security Group values are taken from machine profile.
+            # security_groups = [
+            #     "default"
+            # ]
+            machine_profile = {
+                vm_name = "example-vm-name"
+                vm_id = "i-xxxxxxxxx"
+                vm_region_az = "us-east-1c"  # Example. Chose the region and availability zone where your VM is located.
+                # For machine profile, you can either provide VM related details or launch template related details, but not both.
+                # launch_template_name = "example_launch_template"
+                # launch_template_id = "lt-example"
+                # launch_template_version = "1"
+            }
+            tenancy_type = "Shared"
+        }
+		number_of_total_machines =  1
+        machine_account_creation_rules ={
+			naming_scheme 	   = "aws-multi-##"
+			naming_scheme_type = "Numeric"
+        }
+    }	
+}
+
 resource "citrix_machine_catalog" "example-gcp-mtsession" {
     name                        = "example-gcp-mtsession"
     description                 = "Example multi-session catalog on GCP hypervisor"

--- a/internal/quickcreate/qcs_account/aws_workspaces_account_resource_model.go
+++ b/internal/quickcreate/qcs_account/aws_workspaces_account_resource_model.go
@@ -97,6 +97,12 @@ func (AwsWorkspacesAccountResourceModel) GetAttributes() map[string]schema.Attri
 	return AwsWorkspacesAccountResourceModel{}.GetSchema().Attributes
 }
 
+func (AwsWorkspacesAccountResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{
+		"aws_access_key_id": true,
+	}
+}
+
 func (r AwsWorkspacesAccountResourceModel) RefreshPropertyValues(account *quickcreateservice.AwsEdcAccount) AwsWorkspacesAccountResourceModel {
 	r.AccountId = types.StringValue(account.GetAccountId())
 	r.Name = types.StringValue(account.GetName())

--- a/internal/quickcreate/qcs_connection/aws_workspaces_directory_connection_resource_model.go
+++ b/internal/quickcreate/qcs_connection/aws_workspaces_directory_connection_resource_model.go
@@ -152,6 +152,10 @@ func (AwsWorkspacesDirectoryConnectionModel) GetAttributes() map[string]schema.A
 	return AwsWorkspacesDirectoryConnectionModel{}.GetSchema().Attributes
 }
 
+func (AwsWorkspacesDirectoryConnectionModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r AwsWorkspacesDirectoryConnectionModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, isResource bool, directory *quickcreateservice.AwsEdcDirectoryConnection) AwsWorkspacesDirectoryConnectionModel {
 	r.DirectoryConnectionId = types.StringValue(directory.GetConnectionId())
 	r.Name = types.StringValue(directory.GetName())

--- a/internal/quickcreate/qcs_image/aws_workspaces_image_resource_model.go
+++ b/internal/quickcreate/qcs_image/aws_workspaces_image_resource_model.go
@@ -137,6 +137,10 @@ func (AwsWorkspacesImageModel) GetAttributes() map[string]schema.Attribute {
 	return AwsWorkspacesImageModel{}.GetSchema().Attributes
 }
 
+func (AwsWorkspacesImageModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r AwsWorkspacesImageModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, isResource bool, image *quickcreateservice.AwsEdcImage) AwsWorkspacesImageModel {
 	r.Id = types.StringValue(image.GetImageId())
 	r.AccountId = types.StringValue(image.GetAccountId())

--- a/internal/quickdeploy/cma_image/template_image_resource_model.go
+++ b/internal/quickdeploy/cma_image/template_image_resource_model.go
@@ -141,6 +141,10 @@ func (CitrixManagedAzureImageResourceModel) GetAttributes() map[string]schema.At
 	return CitrixManagedAzureImageResourceModel{}.GetSchema().Attributes
 }
 
+func (CitrixManagedAzureImageResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r CitrixManagedAzureImageResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, isResource bool, image *catalogservice.TemplateImageDetails, region *catalogservice.DeploymentRegionModel) CitrixManagedAzureImageResourceModel {
 	r.Id = types.StringValue(image.GetId())
 	r.Name = types.StringValue(image.GetName())

--- a/internal/storefront/stf_authentication/stf_authentication_service_resource_model.go
+++ b/internal/storefront/stf_authentication/stf_authentication_service_resource_model.go
@@ -103,3 +103,7 @@ func (STFAuthenticationServiceResourceModel) GetSchema() schema.Schema {
 func (STFAuthenticationServiceResourceModel) GetAttributes() map[string]schema.Attribute {
 	return STFAuthenticationServiceResourceModel{}.GetSchema().Attributes
 }
+
+func (STFAuthenticationServiceResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}

--- a/internal/storefront/stf_deployment/stf_deployment_resource_model.go
+++ b/internal/storefront/stf_deployment/stf_deployment_resource_model.go
@@ -366,6 +366,10 @@ func (STFDeploymentResourceModel) GetAttributes() map[string]schema.Attribute {
 	return STFDeploymentResourceModel{}.GetSchema().Attributes
 }
 
+func (STFDeploymentResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}
+
 func (r *STFDeploymentResourceModel) RefreshRoamingBeacon(ctx context.Context, diagnostics *diag.Diagnostics, roamInt *citrixstorefront.GetSTFRoamingInternalBeaconResponseModel, roamExt *citrixstorefront.GetSTFRoamingExternalBeaconResponseModel) {
 	refreshedRoamingBeacon := util.ObjectValueToTypedObject[RoamingBeacon](ctx, diagnostics, r.RoamingBeacon)
 	if roamInt.Internal[len(roamInt.Internal)-1:] != "/" {

--- a/internal/storefront/stf_multi_site/stf_user_farm_mapping_resource_model.go
+++ b/internal/storefront/stf_multi_site/stf_user_farm_mapping_resource_model.go
@@ -241,3 +241,7 @@ func (STFUserFarmMappingResourceModel) GetSchema() schema.Schema {
 func (STFUserFarmMappingResourceModel) GetAttributes() map[string]schema.Attribute {
 	return STFUserFarmMappingResourceModel{}.GetSchema().Attributes
 }
+
+func (STFUserFarmMappingResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}

--- a/internal/storefront/stf_webreceiver/stf_webreceiver_resource_model.go
+++ b/internal/storefront/stf_webreceiver/stf_webreceiver_resource_model.go
@@ -1023,3 +1023,7 @@ func (STFWebReceiverResourceModel) GetSchema() schema.Schema {
 func (STFWebReceiverResourceModel) GetAttributes() map[string]schema.Attribute {
 	return STFWebReceiverResourceModel{}.GetSchema().Attributes
 }
+
+func (STFWebReceiverResourceModel) GetAttributesNamesToMask() map[string]bool {
+	return map[string]bool{}
+}

--- a/internal/util/common.go
+++ b/internal/util/common.go
@@ -227,6 +227,8 @@ const NamespaceResourceType string = "Namespace"
 const SecurityGroupResourceType = "SecurityGroup"
 const HostResourceType = "Host"
 const HostGroupResourceType = "HostGroup"
+const LaunchTemplateResourceType = "LaunchTemplate"
+const LaunchTemplateVersionResourceType = "LaunchTemplateVersion"
 
 // Azure Storage Types
 const StandardLRS = "Standard_LRS"
@@ -821,8 +823,8 @@ func GetSTFSTAUrlKey(remote citrixstorefront.STFSTAUrlModel) string {
 	return *remote.StaUrl.Get()
 }
 
-func GetQcsAwsWorkspacesWithUsernameKey(remote citrixquickcreate.AwsEdcDeploymentMachine) string {
-	return remote.GetUsername()
+func GetQcsAwsWorkspacesWithMachineIdKey(remote citrixquickcreate.AwsEdcDeploymentMachine) string {
+	return remote.GetMachineId()
 }
 
 // <summary>
@@ -1307,8 +1309,13 @@ func VerifyIdentityUserListCompleteness(inputUserNames []string, remoteUsers []c
 	return nil
 }
 
-func GetConfigValuesForSchema(ctx context.Context, diags *diag.Diagnostics, m ResourceModelWithAttributes) (string, map[string]interface{}) {
+func GetConfigValuesForSchema(ctx context.Context, diags *diag.Diagnostics, m ResourceModelWithAttributeMasking) (string, map[string]interface{}) {
+	maskedFields := m.GetAttributesNamesToMask()
 	sensitiveFields := GetSensitiveFieldsForAttribute(ctx, diags, m.GetAttributes())
+
+	for key, value := range maskedFields {
+		sensitiveFields[key] = value
+	}
 	dataObj := TypedObjectToObjectValue(ctx, diags, m)
 	return reflect.TypeOf(m).String(), GetConfigValuesForObject(ctx, diags, dataObj, sensitiveFields)
 }

--- a/internal/util/image.go
+++ b/internal/util/image.go
@@ -422,6 +422,192 @@ func (AzureImageSpecsModel) GetAttributes() map[string]schema.Attribute {
 	return AzureImageSpecsModel{}.GetSchema().Attributes
 }
 
+type AwsMachineProfileModel struct {
+	VmName                types.String `tfsdk:"vm_name"`
+	VmRegionAZ            types.String `tfsdk:"vm_region_az"`
+	VmId                  types.String `tfsdk:"vm_id"`
+	LaunchTemplateName    types.String `tfsdk:"launch_template_name"`
+	LaunchTemplateVersion types.String `tfsdk:"launch_template_version"`
+	LaunchTemplateId      types.String `tfsdk:"launch_template_id"`
+}
+
+func (AwsMachineProfileModel) GetSchema() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Description: "The name of the virtual machine that will be used to identify the default value for the tags, virtual machine size, boot diagnostics, host cache property of OS disk, accelerated networking and availability zone." + "<br />" +
+			"While providing machine profile, specify either `vm_name + vm_region_az + vm_id` or `launch_template_name + launch_template_version + launch_template_id`, but not both.",
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"vm_name": schema.StringAttribute{
+				Description: "The name of the machine profile virtual machine.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRelative().AtParent().AtName("vm_region_az"),
+						path.MatchRelative().AtParent().AtName("vm_id"),
+					}...),
+					stringvalidator.ExactlyOneOf(path.Expressions{
+						path.MatchRelative().AtParent().AtName("launch_template_name"),
+					}...),
+				},
+			},
+			"vm_region_az": schema.StringAttribute{
+				Description: "The region and availability zone of the machine profile virtual machine.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRelative().AtParent().AtName("vm_name"),
+						path.MatchRelative().AtParent().AtName("vm_id"),
+					}...),
+				},
+			},
+			"vm_id": schema.StringAttribute{
+				Description: "The instance ID of the machine profile virtual machine.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRelative().AtParent().AtName("vm_name"),
+						path.MatchRelative().AtParent().AtName("vm_region_az"),
+					}...),
+				},
+			},
+			"launch_template_name": schema.StringAttribute{
+				Description: "The launch template name of the machine profile.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRelative().AtParent().AtName("launch_template_version"),
+						path.MatchRelative().AtParent().AtName("launch_template_id"),
+					}...),
+				},
+			},
+			"launch_template_version": schema.StringAttribute{
+				Description: "The launch template version of the machine profile.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRelative().AtParent().AtName("launch_template_name"),
+						path.MatchRelative().AtParent().AtName("launch_template_id"),
+					}...),
+				},
+			},
+			"launch_template_id": schema.StringAttribute{
+				Description: "The launch template ID of the machine profile.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.Expressions{
+						path.MatchRelative().AtParent().AtName("launch_template_name"),
+						path.MatchRelative().AtParent().AtName("launch_template_version"),
+					}...),
+				},
+			},
+		},
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.RequiresReplaceIf(
+				func(_ context.Context, req planmodifier.ObjectRequest, resp *objectplanmodifier.RequiresReplaceIfFuncResponse) {
+					resp.RequiresReplace = req.ConfigValue.IsNull() != req.StateValue.IsNull()
+				},
+				"Force replace when machine_profile is added or removed. Update is allowed only if previously set.",
+				"Force replace when machine_profile is added or removed. Update is allowed only if previously set.",
+			),
+		},
+		Validators: []validator.Object{
+			objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("security_groups")),
+		},
+	}
+}
+
+func (AwsMachineProfileModel) GetAttributes() map[string]schema.Attribute {
+	return AwsMachineProfileModel{}.GetSchema().Attributes
+}
+
+func HandleMachineProfileForAwsMcsPvsCatalog(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diag *diag.Diagnostics, hypervisorName string, resourcePoolName string, machineProfile AwsMachineProfileModel, errorTitle string) (string, error) {
+	isUsingImageTemplate := false
+	if machineProfile.VmName.IsNull() || machineProfile.VmName.IsUnknown() {
+		isUsingImageTemplate = true
+	}
+
+	if isUsingImageTemplate {
+		launchTemplateName := machineProfile.LaunchTemplateName.ValueString()
+		launchTemplateVersion := machineProfile.LaunchTemplateVersion.ValueString()
+		launchTemplateId := machineProfile.LaunchTemplateId.ValueString()
+
+		folderPath := fmt.Sprintf("%s (%s).launchtemplate", launchTemplateName, launchTemplateId)
+
+		launchTemplate := fmt.Sprintf("%s (%s)", launchTemplateId, launchTemplateVersion)
+		machineProfilePath, httpResp, err := GetSingleResourcePathFromHypervisorWithNoCacheRetry(ctx, client, diag, hypervisorName, resourcePoolName, folderPath, launchTemplate, LaunchTemplateVersionResourceType, "")
+		if err != nil {
+			diag.AddError(
+				errorTitle,
+				"TransactionId: "+citrixdaasclient.GetTransactionIdFromHttpResponse(httpResp)+
+					fmt.Sprintf("\nFailed to locate machine profile launch template %s with version %s on AWS, error: %s", folderPath, launchTemplate, err.Error()),
+			)
+			return "", fmt.Errorf("Failed to locate machine profile launch template %s with version %s on AWS, error: %s", folderPath, launchTemplate, err.Error())
+		}
+		return machineProfilePath, nil
+	} else {
+		machineProfileVmName := machineProfile.VmName.ValueString()
+		machineProfileVmRegionAZ := machineProfile.VmRegionAZ.ValueString()
+		machineProfileVmId := machineProfile.VmId.ValueString()
+
+		folderPath := fmt.Sprintf("%s.availabilityzone", machineProfileVmRegionAZ)
+
+		awsMachineProfile := fmt.Sprintf("%s (%s)", machineProfileVmName, machineProfileVmId)
+		machineProfilePath, httpResp, err := GetSingleResourcePathFromHypervisorWithNoCacheRetry(ctx, client, diag, hypervisorName, resourcePoolName, folderPath, awsMachineProfile, VirtualMachineResourceType, "")
+		if err != nil {
+			diag.AddError(
+				errorTitle,
+				"TransactionId: "+citrixdaasclient.GetTransactionIdFromHttpResponse(httpResp)+
+					fmt.Sprintf("\nFailed to locate machine profile %s on AWS, error: %s", machineProfileVmName, err.Error()),
+			)
+			return "", fmt.Errorf("Failed to locate machine profile VM %s on AWS, error: %s", machineProfileVmName, err.Error())
+		}
+		return machineProfilePath, nil
+	}
+}
+
+func ParseAwsMachineProfileResponseToModel(machineProfileResponse citrixorchestration.HypervisorResourceRefResponseModel) *AwsMachineProfileModel {
+	machineProfileModel := AwsMachineProfileModel{}
+	if machineProfileName := machineProfileResponse.GetName(); machineProfileName != "" {
+		machineProfileSegments := strings.Split(machineProfileResponse.GetXDPath(), "\\")
+		lastIndex := len(machineProfileSegments) - 1
+		if strings.HasSuffix(machineProfileSegments[lastIndex], "Vm") {
+			machineProfileModel.VmName = types.StringValue(strings.Split(machineProfileName, " (i-")[0])
+			machineProfileModel.VmId = types.StringValue(strings.TrimSuffix((strings.Split(machineProfileName, " (")[1]), ")"))
+		} else {
+			launchTemplateVersion := strings.TrimSuffix(machineProfileSegments[lastIndex], ".launchtemplateversion")
+			machineProfileModel.LaunchTemplateId = types.StringValue(strings.Split(launchTemplateVersion, " (")[0])
+			machineProfileModel.LaunchTemplateVersion = types.StringValue(strings.TrimSuffix((strings.Split(launchTemplateVersion, " (")[1]), ")"))
+		}
+
+		regionAzIndex := slices.IndexFunc(machineProfileSegments, func(machineProfileSegment string) bool {
+			return strings.Contains(machineProfileSegment, ".availabilityzone")
+		})
+
+		if regionAzIndex != -1 {
+			regionAZ := strings.TrimSuffix(machineProfileSegments[regionAzIndex], ".availabilityzone")
+			machineProfileModel.VmRegionAZ = types.StringValue(regionAZ)
+		}
+
+		templateNameIndex := slices.IndexFunc(machineProfileSegments, func(machineProfileSegment string) bool {
+			return strings.Contains(machineProfileSegment, ".launchtemplate")
+		})
+
+		if templateNameIndex != -1 {
+			launchTemplate := strings.TrimSuffix(machineProfileSegments[templateNameIndex], ".launchtemplate")
+			templateName := strings.Split(launchTemplate, " (")[0]
+			machineProfileModel.LaunchTemplateName = types.StringValue(templateName)
+		}
+	} else {
+		machineProfileModel.VmName = types.StringNull()
+		machineProfileModel.VmId = types.StringNull()
+		machineProfileModel.VmRegionAZ = types.StringNull()
+		machineProfileModel.LaunchTemplateName = types.StringNull()
+		machineProfileModel.LaunchTemplateVersion = types.StringNull()
+		machineProfileModel.LaunchTemplateId = types.StringNull()
+	}
+	return &machineProfileModel
+}
+
 func HandleMachineProfileForAzureMcsPvsCatalog(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diag *diag.Diagnostics, hypervisorName string, resourcePoolName string, machineProfile AzureMachineProfileModel, errorTitle string) (string, error) {
 	machineProfileResourceGroup := machineProfile.MachineProfileResourceGroup.ValueString()
 	machineProfileVmOrTemplateSpecVersion := machineProfile.MachineProfileVmName.ValueString()

--- a/internal/util/types.go
+++ b/internal/util/types.go
@@ -17,6 +17,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
+type ResourceModelWithAttributeMasking interface {
+	ResourceModelWithAttributes
+	GetAttributesNamesToMask() map[string]bool
+}
+
 type ResourceModelWithAttributes interface {
 	GetAttributes() map[string]resourceSchema.Attribute // workaround because NestedAttributeObject and SingleNestedAttribute do not share a base type
 }

--- a/scripts/object-ids-helper/cvad-object-ids.ps1
+++ b/scripts/object-ids-helper/cvad-object-ids.ps1
@@ -27,7 +27,7 @@ Currently this script is still in TechPreview
     For Citrix Cloud customers (Optional): Use this to force override the Citrix DaaS service hostname.
 
 .Parameter Environment
-    The Citrix Cloud environment of the customer. Only applicable for Citrix Cloud customers. Available options: Production, Staging
+    The Citrix Cloud environment of the customer. Only applicable for Citrix Cloud customers. Available options: Production, Japan, Gov
 
 .Parameter DisableSSLValidation
     Disable SSL validation for this script. Required if DDC does not have a valid SSL certificate.
@@ -52,7 +52,7 @@ Param (
     [string] $Hostname = "api.cloud.com",
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("Production", "Staging")]
+    [ValidateSet("Production", "Staging", "Japan", "JapanStaging", "Gov", "GovStaging")]
     [string] $Environment = "Production",
 
     [Parameter(Mandatory = $false)]
@@ -170,6 +170,18 @@ function Get-AuthToken {
         elseif ($script:environment -eq "Staging") {
             $url = "https://api.cloudburrito.com/cctrustoauth2/$script:customerId/tokens/clients"
         }
+        elseif ($script:environment -eq "Japan") {
+            $url = "https://api.citrixcloud.jp/cctrustoauth2/$script:customerId/tokens/clients"
+        }
+        elseif ($script:environment -eq "JapanStaging") {
+            $url = "https://api.citrixcloud-test.jp/cctrustoauth2/$script:customerId/tokens/clients"
+        }
+        elseif ($script:environment -eq "Gov") {
+            $url = "https://api.citrixcloud.us/cctrustoauth2/$script:customerId/tokens/clients"
+        }
+        elseif ($script:environment -eq "GovStaging") {
+            $url = "https://api.citrixcloud-test.us/cctrustoauth2/$script:customerId/tokens/clients"
+        }
 
         $body = @{
             grant_type    = 'client_credentials'
@@ -226,8 +238,20 @@ function Get-UrlForWemObjects {
     if ($script:environment -eq "Production") {
         $script:wemHostName = "api.wem.cloud.com"
     }
-    else {
+    elseif ($script:environment -eq "Staging") {
         $script:wemHostName = "api.wem.cloudburrito.com"
+    }
+    elseif ($script:environment -eq "Japan") {
+        $script:wemHostName = "api.wem.citrixcloud.jp"
+    }
+    elseif ($script:environment -eq "JapanStaging") {
+        $script:wemHostName = "api.wem.citrixcloud-test.jp"
+    }
+    elseif ($script:environment -eq "Gov") {
+        $script:wemHostName = "api.wem.citrixcloud.us"
+    }
+    elseif ($script:environment -eq "GovStaging") {
+        $script:wemHostName = "api.wem.citrixcloud-test.us"
     }
 
     if ($requestPath -eq "sites") {

--- a/scripts/onboarding-helper/README.md
+++ b/scripts/onboarding-helper/README.md
@@ -22,6 +22,22 @@ This automation script is designed to onboard an existing site to Terraform. It 
 3. Set up the Citrix Terraform provider locally. For instructions, refer to the [Citrix Provider Documentation](https://registry.terraform.io/providers/citrix/citrix/latest/docs).
 4. (Cloud only) create a [Citrix Cloud service principal](https://developer-docs.citrix.com/en-us/citrix-cloud/citrix-cloud-api-overview/get-started-with-citrix-cloud-apis#citrix-cloud-api-access-with-service-principals) with at least the `Read Only Administrator` role to the DDC. This will be used for the `ClientId` and `ClientSecret` in the next step.
 
+## Recommended Approach for New Users
+
+For administrators who are new to Terraform and Citrix, we recommend starting small by onboarding a limited set of resources rather than your entire Citrix site at once. This approach makes the learning process more manageable and less overwhelming.
+
+We recommend using the following parameters when running the onboarding script:
+
+- Use the `-ResourceTypes` parameter to specify just a few resource types (for example `citrix_zone`, `citrix_delivery_group`)
+- Use the `-NamesOrIds` parameter to filter for specific resources by name or ID
+
+Example:
+```powershell
+.\terraform-onboarding.ps1 -CustomerId "{CustomerId}" -ClientId "{ClientId}" -ClientSecret "{ClientSecret}" -ResourceTypes "citrix_zone","citrix_delivery_group" -NamesOrIds "Primary Zone","Sales Delivery Group"
+```
+
+This incremental approach allows you to become familiar with Terraform concepts and the Citrix provider while working with a smaller, more focused set of resources.
+
 ## Onboarding Process
 
 1. Create a new folder for your Terraform project.
@@ -39,9 +55,9 @@ This automation script is designed to onboard an existing site to Terraform. It 
     ```
   - For Citrix on-premises customers
     ```powershell
-    .\terraform-onboarding.ps1 -ClientId "{ClientId}" -ClientSecret "{ClientSecret}" -DomainFqdn "{Domain FQDN}" -HostName "{HostName}"
+    .\terraform-onboarding.ps1 -ClientId "{Username}" -ClientSecret "{Password}" -DomainFqdn "{Domain FQDN}" -HostName "{HostName}"
     ```
-    Replace the placeholders `{...}` with your actual values. Here's what each parameter means:
+    Replace the placeholders `{...}` with your actual values. Here's what each parameter means, in addition to the optional parameters:
     - `CustomerId`: 
       - For Citrix Cloud customers **only** (Required): Your Citrix Cloud customer ID. This is only applicable for Citrix Cloud customers.
     - `ClientId`: Your client ID for Citrix DaaS service authentication.
@@ -56,21 +72,56 @@ This automation script is designed to onboard an existing site to Terraform. It 
       - For Citrix on-premises customers (Required): Use this to specify Delivery Controller hostname.
       - For Citrix Cloud customers (Optional): Use this to force override the Citrix DaaS service hostname.
     - `Environment`: 
-      - For Citrix Cloud customers **only** (Optional): Your Citrix Cloud environment. The available options are `Production` and `Staging`. The default value is `Production`.
-    - `SetDependencyRelationship` (Switch): Add this switch to create dependency relationships between resources by replacing resource ID with resource references.
+      - For Citrix Cloud customers **only** (Optional): Your Citrix Cloud environment. The available options are `Production`, `Japan`, and `Gov`. The default value is `Production`.
+    - `ResourceTypes` (Array):
+      - Optional list of resource types to onboard. When specified, only those resources will be onboarded, the rest skipped. This helps make the onboarding process more manageable by limiting the scope.
+      - By default (if `-NoDependencyRelationship` is not specified), will resolve all dependency relationships between resources as long as the dependent resource is included.
+      - Available resource types include: `citrix_admin_folder`, `citrix_admin_role`, `citrix_admin_scope`, `citrix_admin_user`, `citrix_application`, `citrix_application_group`, `citrix_application_icon`, `citrix_aws_hypervisor`, `citrix_azure_hypervisor`, `citrix_delivery_group`, `citrix_gcp_hypervisor`, `citrix_image_definition`, `citrix_machine_catalog`, `citrix_nutanix_hypervisor`, `citrix_openshift_hypervisor`, `citrix_policy_set`, `citrix_scvmm_hypervisor`, `citrix_service_account`, `citrix_storefront_server`, `citrix_tag`, `citrix_vsphere_hypervisor`, `citrix_wem_configuration_set`, `citrix_wem_directory_object`, `citrix_xenserver_hypervisor`, `citrix_zone`.
+      - `citrix_<hypervisorType>_resource_pools` are included with the `citrix_<hypervisorType>_hypervisor` resource.
+      - `citrix_image_version` is included with the `citrix_image_definition` resource.
+    - `NamesOrIds` (Array):
+      - Optional string array parameter to filter resources by name or ID. Only resources with a Name or ID matching any of these values will be onboarded.
+      - This allows you to onboard multiple specific resources by name or ID in a single operation.
+      - By default if (`-NoDependencyRelationship` is not specified), will resolve all dependency relationships between resources as long as the dependent resource is included.
+    - `NoDependencyRelationship` (Switch): Add this switch to remove dependency relationships between resources by replacing resource references with resource IDs.
     - `DisableSSLValidation` (Switch):
       - For Citrix on-premises customers **only**: Add this switch to disable SSL validation on both the PowerShell session and the provider client. SSL validation has to be disabled for this script to work if your on-premises DDC does not have a valid SSL certificate.
     - `ShowClientSecret` (Switch):
       - Use this switch to include the client secret value in the generated Terraform configuration file. Defaults to `$false` to ensure security.
 
 7. Wait for the script to complete. The execution time will depend on the complexity of the onboarding process and the resources being imported.
-
 8. Once the script has finished running, check the `.tf` files for the output. The Terraform state file should also be updated with the site terraform resources.
 9. Please note that the onboarding script masks out values for all sensitive attributes present in the generated terraform files. Please update these placeholders with the appropriate values.
 10. At this point if you run `terraform plan`, you should **only** see the sensitive attributes from step 9 being updated.
 11. Run `terraform apply`. This will synchronize the state file with the values of the sensitive attributes updated in step 9.
 12. If you run `terraform plan` again, you should see the following message: `No changes. Your infrastructure matches the configuration.`. This indicates that all the Citrix resources have been successfully onboarded.
 
+## Examples
+```powershell
+# Cloud customer importing all resources
+.\terraform-onboarding.ps1 -CustomerId "{CustomerId}" -ClientId "{ClientId}" -ClientSecret "{ClientSecret}"
+
+# Cloud customer import all resources without dependency relationships
+.\terraform-onboarding.ps1 -CustomerId "{CustomerId}" -ClientId "{ClientId}" -ClientSecret "{ClientSecret}" -NoDependencyRelationship
+
+# Cloud customer importing a subset of resources
+.\terraform-onboarding.ps1 -CustomerId "{CustomerId}" -ClientId "{ClientId}" -ClientSecret "{ClientSecret}" -ResourceTypes "citrix_zone","citrix_delivery_group" -NamesOrIds "Primary Zone","Sales Delivery Group"
+
+# Cloud customer importing a subset of resources without dependency relationships
+.\terraform-onboarding.ps1 -CustomerId "{CustomerId}" -ClientId "{ClientId}" -ClientSecret "{ClientSecret}" -ResourceTypes "citrix_zone","citrix_delivery_group" -NamesOrIds "Primary Zone","Sales Delivery Group" -NoDependencyRelationship
+
+# On-premises customer importing all resources
+.\terraform-onboarding.ps1 -ClientId "{Username}" -ClientSecret "{Password}" -DomainFqdn "{Domain FQDN}" -HostName "{HostName}"
+
+# On-premises customer import all resources without dependency relationships
+.\terraform-onboarding.ps1 -ClientId "{Username}" -ClientSecret "{Password}" -DomainFqdn "{Domain FQDN}" -HostName "{HostName}" -NoDependencyRelationship
+
+# On-premises customer importing a subset of resources
+.\terraform-onboarding.ps1 -ClientId "{Username}" -ClientSecret "{Password}" -DomainFqdn "{Domain FQDN}" -HostName "{HostName}" -ResourceTypes "citrix_zone","citrix_delivery_group" -NamesOrIds "Primary Zone","Sales Delivery Group"
+
+# On-premises customer importing a subset of resources without dependency relationships
+.\terraform-onboarding.ps1 -ClientId "{Username}" -ClientSecret "{Password}" -DomainFqdn "{Domain FQDN}" -HostName "{HostName}" -ResourceTypes "citrix_zone","citrix_delivery_group" -NamesOrIds "Primary Zone","Sales Delivery Group" -NoDependencyRelationship
+```
 
 ## Known Issues/Debugging:
 1. While running the script for On-Premises customers if it throws an exception as stated below:
@@ -81,5 +132,5 @@ Invoke-WebRequest : The underlying connection was closed: Could not establish tr
 Solution : 
 Disable SSL validation by adding `-DisableSSLValidation` to the command.
 ```powershell
-.\terraform-onboarding.ps1 -ClientId "{ClientId}" -ClientSecret "{ClientSecret}" -DomainFqdn "{Domain FQDN}" -HostName "{HostName}" -DisableSSLValidation
+.\terraform-onboarding.ps1 -ClientId "{Username}" -ClientSecret "{Password}" -DomainFqdn "{Domain FQDN}" -HostName "{HostName}" -DisableSSLValidation
 ```

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -18,9 +18,33 @@ Check out the [release notes](https://github.com/citrix/terraform-provider-citri
 
 New to Terraform? Click [here](https://developer.hashicorp.com/terraform) to learn more.
 
-### Importing existing Citrix resources into Terraform
+### Roadmap Proposal for a Smoother Onboarding Experience
+To streamline your onboarding experience with the Citrix Terraform Provider, we recommend to start small by importing or creating one or two resources and build out from there.
 
-Experience the immediate benefits of Terraform by importing your Citrix resources (CVAD or DaaS) using our [Onboarding Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/onboarding-helper/terraform-onboarding.ps1). This allows you to quickly adopt infrastructure as code and streamline your infrastructure management. A comprehensive [ReadMe](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/onboarding-helper/README.md) is available to guide you through the process.
+#### Import Your Existing Resources Using the Onboarding Script
+Use our [Onboarding Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/onboarding-helper/) with the following parameters to import existing resources and create Terraform configuration files for them.
+
+- Use the `-ResourceTypes` parameter to specify just a few resource types (for example `citrix_zone`, `citrix_delivery_group`)
+- Use the `-NamesOrIds` parameter to filter for specific resources by name or ID
+
+Example:
+```powershell
+.\terraform-onboarding.ps1 CustomerId "{CustomerId}" -ClientId "{ClientId}" -ClientSecret "{ClientSecret}" -ResourceTypes "citrix_zone","citrix_delivery_group" -NamesOrIds "Primary Zone","Sales Delivery Group"
+```
+
+This incremental approach allows you to become familiar with Terraform concepts and the Citrix provider while working with a smaller, more focused set of resources.
+
+#### Manual Configuration
+Alternatively, we recommend starting by creating new `.tf` files for the core resources essential for a Citrix deployment:
+
+- [citrix_cloud_resource_location](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/cloud_resource_location) (for Citrix Cloud customers only)
+- [citrix_zone](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/zone)
+- citrix_{hosting provider}_hypervisor
+- citrix_{hosting provider}_hypervisor_resource_pool
+
+These resources are straightforward to configure and can be created or removed quickly. Begin your Terraform journey with these resources to build confidence in managing your Citrix deployment via Terraform.
+
+Once these resources are properly configured, the next step is to set up your [machine catalog](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/machine_catalog) with Terraform. Managing the machine catalog with Terraform will provide a solid foundation for designing a pipeline that meets your specific use case.
 
 ### Creating Citrix resources via Terraform
 
@@ -42,18 +66,6 @@ Basic example templates for getting started can be found in our [GitHub reposito
 [![alt text](https://raw.githubusercontent.com/citrix/terraform-provider-citrix/refs/heads/main/images/techzone-youtube-thumbnail.png)](https://www.youtube.com/watch?v=c33sMLaCVjY)
 https://www.youtube.com/watch?v=c33sMLaCVjY
 
-### Roadmap Proposal for a Smoother Onboarding Experience
-To streamline your onboarding experience with the Citrix Terraform Provider, we recommend starting with the core resources essential for a Citrix deployment:
-
-- Resource Location (for Citrix Cloud customers only)
-- Zone
-- Hypervisor
-- Hypervisor Resource Pool
-
-These resources are straightforward to configure and can be created or removed quickly. Begin your Terraform journey with these resources to build confidence in managing your Citrix deployment via Terraform.
-
-Once these resources are properly configured, the next step is to set up your [machine catalog](https://registry.terraform.io/providers/citrix/citrix/latest/docs/resources/machine_catalog) with Terraform. Managing the machine catalog with Terraform will provide a solid foundation for designing a pipeline that meets your specific use case.
-
 ### (On-Premises Only) Enable Web Studio
 
 For on-premises sites with version >= 2311 are supported. Web Studio needs to be [installed and configured](https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/install-configure/install-core/install-web-studio.html#install-web-studio-1) for the provider to work.
@@ -73,25 +85,25 @@ A service principal is an API client which is not associated with an email. It c
 
 ### What resource is supported for different connection types?
 
-| Connection Type                         |   Hypervisor       |   Resource Pool          |  MCS Power Managed         | MCS Provisioning           |          PVS             | Manual/Remote PC     |
-|-----------------------------------------|--------------------|--------------------------|----------------------------|----------------------------|--------------------------|----------------------|
-| AzureRM                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_check_mark:        | :heavy_check_mark:   |
-| AWS EC2                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| GCP                                     |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| vSphere                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| XenServer                               |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| Nutanix                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| SCVMM                                   |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| Red Hat OpenShift (**Techpreview**)     |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| HPE Moonshot (**Techpreview**)          |:heavy_check_mark:  |:heavy_multiplication_x:  | :heavy_check_mark:         | :heavy_multiplication_x:   |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| Remote PC Wake On LAN (**Techpreview**) |:heavy_check_mark:  |:heavy_multiplication_x:  | :heavy_multiplication_x:   | :heavy_multiplication_x:   |:heavy_multiplication_x:  | :heavy_check_mark:   |
+| Connection Type                         |   Hypervisor       |   Resource Pool    |  MCS Power Managed | MCS Provisioning   |         PVS        | Manual/Remote PC     |
+|-----------------------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|----------------------|
+| AzureRM                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   |
+| AWS EC2                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| GCP                                     |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| vSphere                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| XenServer                               |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| Nutanix                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| SCVMM                                   |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| Red Hat OpenShift (**Techpreview**)     |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| HPE Moonshot (**Techpreview**)          |:heavy_check_mark:  | N/A                | :heavy_check_mark: | N/A                | N/A                | :heavy_check_mark:   |
+| Remote PC Wake On LAN (**Techpreview**) |:heavy_check_mark:  | N/A                | N/A                | N/A                | N/A                | :heavy_check_mark:   |
 
 ### What URLs should be whitelisted in order to use the Citrix Terraform provider?
 - URLs of the Citrix admin consoles: please visit [this documentation](https://docs.citrix.com/en-us/citrix-cloud/overview/requirements/internet-connectivity-requirements.html) for more information.
 - URL of the HashiCorp Terraform registry: https://registry.terraform.io or a private registry.
 
 ### How do I get the ID to import a DaaS resource?
-The [Onboarding Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/onboarding-helper/) will discover all resource IDs and import them into a local terraform state file. You can then run `terraform state show` to inspect the state and discover the IDs.
+The [Object IDs Helper Script](https://github.com/citrix/terraform-provider-citrix/blob/main/scripts/object-ids-helper/) will discover all resource IDs and save them to a JSON file for easy reference.
 
 Alternatively the IDs can be found in Web Studio by looking at the network traces. Open your browser developer tools (usually F12) and navigate to the `Network` tab. Refresh Web Studio and click on the resource you want to find the ID for. There should be 2 corresponding network calls (`OPTIONS` then `GET`) for the resource which includes the ID as the last path in the url before the `?` query.
 


### PR DESCRIPTION
**New Features:**
- Added support for `machine_profile` parameter in the `citrix_machine_catalog.provisioning_scheme.aws_machine_config` property. #227

**Bugfixes:**
- Fix issues with Update for `citrix_quickcreate_aws_workspaces_deployment`. #256
- Fixed a bug that caused remote metadata from a zone to be ignored after being managed by Terraform.

**Other Improvements:**
- `security_groups` parameter in `aws_machine_config` is now optional. Do not specify it when using the new `machine_profile` parameter.
- `citrix_machine_catalog` resource will validate name uniqueness during plan phase.
- Updating tflog messages to mask out user specific details.