### PR TITLE
release-v1.0.21

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,58 +7,61 @@ assignees: ''
 
 ---
 
-*Thanks for taking the time to fill out this bug report! Before submitting this issue please check the [open bugs](https://github.com/citrix/terraform-provider-citrix/issues?q=is%3Aissue+is%3Aopen+label%3Abug) to ensure the bug has not already been reported. If it has been reported give it a 👍*
-
-*If this bug is present when using the Citrix service UI or REST APIs then it is not a bug in the provider but rather a bug in the underlying service or the environment. In some cases there can be an enhancement in the provider to handle the error better. Please open a feature request instead of a bug in this case. For more information see [CONTRIBUTING.md#provider-issue-vs-product-issue-vs-configuration-issue](https://github.com/citrix/terraform-provider-citrix/blob/main/CONTRIBUTING.md#provider-issue-vs-product-issue-vs-configuration-issue).*
+<!-- Thanks for taking the time to fill out this bug report! Before submitting this issue please check the [open bugs](https://github.com/citrix/terraform-provider-citrix/issues?q=is%3Aissue+is%3Aopen+label%3Abug) to ensure the bug has not already been reported. If it has been reported give it a 👍 -->
 
 
 ## Describe the bug
 
-*Summary of the issue*
+<!-- Summary of the issue -->
 
 **Terraform command (import, apply, etc):**
 **Resource impacted:**
+<!-- If this bug is present when using the Citrix service UI or REST APIs then it is not a bug in the provider but rather a bug in the underlying service or the environment. In some cases there can be an enhancement in the provider to handle the error better. Please open a feature request instead of a bug in this case. For more information see [CONTRIBUTING.md#provider-issue-vs-product-issue-vs-configuration-issue](https://github.com/citrix/terraform-provider-citrix/blob/main/CONTRIBUTING.md#provider-issue-vs-product-issue-vs-configuration-issue). -->
+**Issue reproducible outside of Terraform:** <!-- Yes/No/Not verified -->
 
 
 ## Versions
 
-*Use the `terraform -v` command to find the Terraform and Citrix Provider versions.*
+<!-- Use the `terraform -v` command to find the Terraform and Citrix Provider versions. -->
 **Terraform:** 
 **citrix/citrix provider:** 
 **Operation system:** 
 
-*For on-premises customers fill out any that apply with the CU or LTSR version (eg 2402).*
+**Environment type:** <!-- Cloud or On-premises -->
+**Hypervisor type (if applicable):** <!-- Azure, AWS, GCP, vSphere, XenServer, Nutanix, etc. -->
+
+<!-- For on-premises customers fill out any that apply with the CU or LTSR version (eg 2402). -->
 **CVAD (DDC, VDA, etc):** 
 **Storefront:** 
 
 ## Terraform configuration files
-*Paste or attach any relevant `.tf` files with secrets and identifying information removed.*
+<!-- Paste or attach any relevant `.tf` files with secrets and identifying information removed. -->
 
 
 ## Terraform console output
-*Paste the output from Terraform CLI including any errors and the transactionIds if present.*
+<!-- Paste the output from Terraform CLI including any errors and the transactionIds if present. Errors with TransactionIDs are critical for troubleshooting.
 
-*If the output references a file in the temp directory include it as well.*
+If the output references a file in the temp directory include it as well. -->
 
 
 ## Terraform log file
-*If the issue is reproducible enable Terraform debug logging using one of the commands below. Then reproduce the issue and include the resulting log file. More information about Terraform logging is available [here](https://developer.hashicorp.com/terraform/plugin/log/managing#enable-logging).*
+<!-- If the issue is reproducible enable Terraform debug logging using one of the commands below. Then reproduce the issue and include the resulting log file. More information about Terraform logging is available [here](https://developer.hashicorp.com/terraform/plugin/log/managing#enable-logging). -->
 
-*cmd:*
+<!-- cmd: -->
 ```bat
 set TF_LOG="DEBUG"
 set TF_LOG_PATH="./citrix-provider-issue.txt"
 terraform <command>
 ```
 
-*Powershell:*
+<!-- Powershell: -->
 ```powershell
 $env:TF_LOG="DEBUG"
 $env:TF_LOG_PATH="./citrix-provider-issue.txt"
 terraform <command>
 ```
 
-*bash:*
+<!-- bash: -->
 ```bash
 export TF_LOG="DEBUG"
 export TF_LOG_PATH="./citrix-provider-issue.txt"

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-*Thanks for taking the time to fill out this feature request! Before submitting this issue please check the [open feature requests](https://github.com/citrix/terraform-provider-citrix/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement) to ensure the feature has not already been reported. If it has been reported give it a 👍*
+<!-- Thanks for taking the time to fill out this feature request! Before submitting this issue please check the [open feature requests](https://github.com/citrix/terraform-provider-citrix/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement) to ensure the feature has not already been reported. If it has been reported give it a 👍 -->
 
 ## Describe the feature request
-*Fill out the following questions and add any additional information.*
+<!-- Fill out the following questions and add any additional information. -->
 **Summary:**
 
 **Is this an enhancement to an existing resource or data source, if so which one?**
@@ -18,7 +18,7 @@ assignees: ''
 **If this is a new resource or data source describe what it should do.**
 
 **Link to any docs that cover this feature:**
-https://docs.citrix.com/
+<!-- e.g. https://docs.citrix.com/ -->
 
 **Link to any APIs that cover this feature:**
-https://developer-docs.citrix.com/
+<!-- e.g. https://developer-docs.citrix.com/ -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,18 +85,18 @@ A service principal is an API client which is not associated with an email. It c
 
 ### What resource is supported for different connection types?
 
-| Connection Type                         |   Hypervisor       |   Resource Pool          |  MCS Power Managed         | MCS Provisioning           |          PVS             | Manual/Remote PC     |
-|-----------------------------------------|--------------------|--------------------------|----------------------------|----------------------------|--------------------------|----------------------|
-| AzureRM                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_check_mark:        | :heavy_check_mark:   |
-| AWS EC2                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| GCP                                     |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| vSphere                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| XenServer                               |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| Nutanix                                 |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| SCVMM                                   |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| Red Hat OpenShift (**Techpreview**)     |:heavy_check_mark:  |:heavy_check_mark:        | :heavy_check_mark:         | :heavy_check_mark:         |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| HPE Moonshot (**Techpreview**)          |:heavy_check_mark:  |:heavy_multiplication_x:  | :heavy_check_mark:         | :heavy_multiplication_x:   |:heavy_multiplication_x:  | :heavy_check_mark:   |
-| Remote PC Wake On LAN (**Techpreview**) |:heavy_check_mark:  |:heavy_multiplication_x:  | :heavy_multiplication_x:   | :heavy_multiplication_x:   |:heavy_multiplication_x:  | :heavy_check_mark:   |
+| Connection Type                         |   Hypervisor       |   Resource Pool    |  MCS Power Managed | MCS Provisioning   |         PVS        | Manual/Remote PC     |
+|-----------------------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|----------------------|
+| AzureRM                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   |
+| AWS EC2                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| GCP                                     |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| vSphere                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| XenServer                               |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| Nutanix                                 |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| SCVMM                                   |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| Red Hat OpenShift (**Techpreview**)     |:heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | N/A                | :heavy_check_mark:   |
+| HPE Moonshot (**Techpreview**)          |:heavy_check_mark:  | N/A                | :heavy_check_mark: | N/A                | N/A                | :heavy_check_mark:   |
+| Remote PC Wake On LAN (**Techpreview**) |:heavy_check_mark:  | N/A                | N/A                | N/A                | N/A                | :heavy_check_mark:   |
 
 ### What URLs should be whitelisted in order to use the Citrix Terraform provider?
 - URLs of the Citrix admin consoles: please visit [this documentation](https://docs.citrix.com/en-us/citrix-cloud/overview/requirements/internet-connectivity-requirements.html) for more information.

--- a/docs/resources/machine_catalog.md
+++ b/docs/resources/machine_catalog.md
@@ -543,6 +543,28 @@ resource "citrix_machine_catalog" "example-remote-pc" {
     ]
 }
 
+resource "citrix_machine_catalog" "example-remote-pc-wake-on-lan" {
+    name                        = "example-remote-pc-wake-on-lan-catalog"
+    description                 = "Example Remote PC catalog with Wake on LAN"
+    zone                        = "<zone Id>"
+    allocation_type             = "Static"
+    session_support             = "SingleSession"
+    is_power_managed            = true
+    is_remote_pc                = true
+    remote_pc_power_management_hypervisor = citrix_remote_pc_wake_on_lan_hypervisor.example-remotepc-wakeonlan-hypervisor.id
+    provisioning_type           = "Manual"
+    machine_accounts = [
+        {
+            machines = [
+                {
+                    machine_account = "DOMAIN\\MachineName1"
+                    machine_name  = "MachineName1"
+                }
+            ]
+        }
+    ]
+}
+
 resource "citrix_machine_catalog" "example-non-domain-joined-azure-mcs" {
 	name                		= "example-non-domain-joined-azure-mcs"
 	description					= "Example catalog on Azure without domain join"
@@ -623,6 +645,7 @@ resource "citrix_machine_catalog" "example-non-domain-joined-azure-mcs" {
 - `persist_user_changes` (String) Specify if user changes are persisted on the machines in the machine catalog. Choose between `Discard` and `OnLocal`. Defaults to OnLocal for manual or non-PVS single session static catalogs, Discard otherwise.
 - `provisioning_scheme` (Attributes) Machine catalog provisioning scheme. Required when `provisioning_type = MCS` or `provisioning_type = PVS_STREAMING`. (see [below for nested schema](#nestedatt--provisioning_scheme))
 - `remote_pc_ous` (Attributes List) Organizational Units to be included in the Remote PC machine catalog. Only to be used when `is_remote_pc = true`. For adding machines, use `machine_accounts`. (see [below for nested schema](#nestedatt--remote_pc_ous))
+- `remote_pc_power_management_hypervisor` (String) The Id of the remote PC Wake on LAN hypervisor connection. Required only if `is_power_managed = true` and `is_remote_pc = true`.
 - `scopes` (Set of String) The IDs of the scopes for the machine catalog to be a part of.
 - `tags` (Set of String) A set of identifiers of tags to associate with the machine catalog.
 - `timeout` (Attributes) Timeout in minutes for the long-running jobs in machine catalog resource's create, update, delete operation(s). (see [below for nested schema](#nestedatt--timeout))
@@ -688,7 +711,7 @@ Required:
 - `identity_type` (String) The identity type of the machines to be created. Supported values are `ActiveDirectory`, `AzureAD`, and `HybridAzureAD`.
 - `number_of_total_machines` (Number) Number of VDA machines allocated in the catalog.
 
-~> **Please Note** When deleting machines, ensure machines that need to be deleted have no active sessions. For machines with `Static` allocation type, also ensure there are no assigned users. If machines that qualify for deletion are more than the requested number of machines to delete, machines are chosen arbitrarily.
+~> **Please Note** When deleting machines, ensure machines that need to be deleted have no active sessions. For machines with `Static` allocation type, also ensure there are no assigned users.<br /><br />If machines that qualify for deletion are more than the requested number of machines to delete, machines are chosen in the following sequence of priority.<br />1. Machines with no associated Delivery Groups.<br />2. Machines in Maintenance Mode.<br />3. Machines with no active sessions.
 
 Optional:
 

--- a/docs/resources/remote_pc_wake_on_lan_hypervisor.md
+++ b/docs/resources/remote_pc_wake_on_lan_hypervisor.md
@@ -14,7 +14,7 @@ Manages a RemotePC Wake On LAN Connection.
 
 ```terraform
 # Remote PC Wake on LAN Hypervisor
-resource "citrix_remote_pc_wake_on_lan_hypervisor" "example-remotepc-wakeonlan-hypervisor-01" {
+resource "citrix_remote_pc_wake_on_lan_hypervisor" "example-remotepc-wakeonlan-hypervisor" {
     name                = "example-remotepc-wakeonlan-hypervisor"
     zone                = "<Zone Id>"
 }

--- a/internal/daas/hypervisor/remotepc_wake_on_lan_hypervisor_resource.go
+++ b/internal/daas/hypervisor/remotepc_wake_on_lan_hypervisor_resource.go
@@ -131,7 +131,7 @@ func (r *remotePCWakeOnLANHypervisorResource) Read(ctx context.Context, req reso
 	}
 
 	// check if the hypervisor is of type Remote PC Wake On LAN
-	if hypervisor.GetConnectionType() != citrixorchestration.HYPERVISORCONNECTIONTYPE_CUSTOM || hypervisor.GetPluginId() != util.REMOTE_PC_WAKE_ON_LAN_PLUGIN_ID {
+	if hypervisor.GetPluginId() != util.REMOTE_PC_WAKE_ON_LAN_PLUGIN_ID {
 		resp.Diagnostics.AddError(
 			"Error reading Hypervisor",
 			"Hypervisor "+hypervisor.GetName()+" is not a Remote PC Wake On LAN connection type hypervisor.",

--- a/internal/daas/machine_catalog/machine_catalog_common_utils.go
+++ b/internal/daas/machine_catalog/machine_catalog_common_utils.go
@@ -122,6 +122,10 @@ func getRequestModelForCreateMachineCatalog(plan MachineCatalogResourceModel, ct
 			return nil, err
 		}
 		body.SetRemotePCEnrollmentScopes(remotePCEnrollmentScopes)
+		if plan.IsPowerManaged.ValueBool() {
+			body.SetHypervisorConnection(plan.RemotePcPowerManagementHypervisor.ValueString())
+			body.SetMachineType(citrixorchestration.MACHINETYPE_PHYSICAL)
+		}
 	} else {
 		machinesRequest, httpResp, err = getMachinesForManualCatalogs(ctx, diagnostics, client, util.ObjectListToTypedArray[MachineAccountsModel](ctx, diagnostics, plan.MachineAccounts))
 		if err != nil {

--- a/internal/daas/machine_catalog/machine_catalog_manual_utils.go
+++ b/internal/daas/machine_catalog/machine_catalog_manual_utils.go
@@ -385,8 +385,10 @@ func (r MachineCatalogResourceModel) updateCatalogWithMachines(ctx context.Conte
 				hostedMachineName := hosting.GetHostedMachineName()
 
 				if !strings.EqualFold(hypervisorId, machineAccount.Hypervisor.ValueString()) {
-					machinesNotPresetInRemote[strings.ToLower(machineFromPlanName)] = true
-					continue
+					if !r.IsRemotePc.ValueBool() || !r.IsPowerManaged.ValueBool() || !strings.EqualFold(hypervisorId, r.RemotePcPowerManagementHypervisor.ValueString()) {
+						machinesNotPresetInRemote[strings.ToLower(machineFromPlanName)] = true
+						continue
+					}
 				}
 
 				if hypervisorId == "" {
@@ -459,7 +461,7 @@ func (r MachineCatalogResourceModel) updateCatalogWithMachines(ctx context.Conte
 						}
 					}
 				case citrixorchestration.HYPERVISORCONNECTIONTYPE_CUSTOM:
-					if (hyp.GetPluginId() == util.NUTANIX_PLUGIN_ID || hyp.GetPluginId() == util.HPE_MOONSHOT_PLUGIN_ID) && hostedMachineName != "" {
+					if (hyp.GetPluginId() == util.NUTANIX_PLUGIN_ID || hyp.GetPluginId() == util.HPE_MOONSHOT_PLUGIN_ID || hyp.GetPluginId() == util.REMOTE_PC_WAKE_ON_LAN_PLUGIN_ID) && hostedMachineName != "" {
 						if !strings.EqualFold(machineFromPlan.MachineName.ValueString(), hostedMachineName) {
 							machineFromPlan.MachineName = types.StringValue(hostedMachineName)
 						}

--- a/internal/examples/resources/citrix_machine_catalog/resource.tf
+++ b/internal/examples/resources/citrix_machine_catalog/resource.tf
@@ -525,6 +525,28 @@ resource "citrix_machine_catalog" "example-remote-pc" {
     ]
 }
 
+resource "citrix_machine_catalog" "example-remote-pc-wake-on-lan" {
+    name                        = "example-remote-pc-wake-on-lan-catalog"
+    description                 = "Example Remote PC catalog with Wake on LAN"
+    zone                        = "<zone Id>"
+    allocation_type             = "Static"
+    session_support             = "SingleSession"
+    is_power_managed            = true
+    is_remote_pc                = true
+    remote_pc_power_management_hypervisor = citrix_remote_pc_wake_on_lan_hypervisor.example-remotepc-wakeonlan-hypervisor.id
+    provisioning_type           = "Manual"
+    machine_accounts = [
+        {
+            machines = [
+                {
+                    machine_account = "DOMAIN\\MachineName1"
+                    machine_name  = "MachineName1"
+                }
+            ]
+        }
+    ]
+}
+
 resource "citrix_machine_catalog" "example-non-domain-joined-azure-mcs" {
 	name                		= "example-non-domain-joined-azure-mcs"
 	description					= "Example catalog on Azure without domain join"

--- a/internal/examples/resources/citrix_remote_pc_wake_on_lan_hypervisor/resource.tf
+++ b/internal/examples/resources/citrix_remote_pc_wake_on_lan_hypervisor/resource.tf
@@ -1,5 +1,5 @@
 # Remote PC Wake on LAN Hypervisor
-resource "citrix_remote_pc_wake_on_lan_hypervisor" "example-remotepc-wakeonlan-hypervisor-01" {
+resource "citrix_remote_pc_wake_on_lan_hypervisor" "example-remotepc-wakeonlan-hypervisor" {
     name                = "example-remotepc-wakeonlan-hypervisor"
     zone                = "<Zone Id>"
 }

--- a/internal/util/resource.go
+++ b/internal/util/resource.go
@@ -179,7 +179,7 @@ func GetApplicationGroupIdWithPath(ctx context.Context, client *citrixdaasclient
 }
 
 func GetMachineCatalogMachines(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diagnostics *diag.Diagnostics, machineCatalogId string) ([]citrixorchestration.MachineResponseModel, error) {
-	req := client.ApiClient.MachineCatalogsAPIsDAAS.MachineCatalogsGetMachineCatalogMachines(ctx, machineCatalogId).Fields("Id,Name,Hosting,DeliveryGroup,AssignedUsers,AssociatedUsers,AllocationType")
+	req := client.ApiClient.MachineCatalogsAPIsDAAS.MachineCatalogsGetMachineCatalogMachines(ctx, machineCatalogId).Fields("Id,Name,Hosting,DeliveryGroup,InMaintenanceMode,AssignedUsers,AssociatedUsers,AllocationType")
 	req = req.Limit(250)
 
 	responses := []citrixorchestration.MachineResponseModel{}


### PR DESCRIPTION
**New Feature:**
- Added support for the machine catalog for Remote PC Wake On LAN connection **(Tech Preview)**

**Bugfixes:**
- Prioritized the removal of machines not associated with any delivery group or machines placed in maintenance mode over the oldest machines created in a machine catalog while decreasing the `number_of_total_machines` count in the `citrix_machine_catalog` resource. Fixes #258.
- Fixed bug in `provisioning_scheme.machine_account_creation_rules.starts_with` parameter having inconsistent values after apply. Fixes #261