### PR TITLE
release-v1.0.33

### DIFF
--- a/docs/resources/quickdeploy_catalog.md
+++ b/docs/resources/quickdeploy_catalog.md
@@ -22,7 +22,7 @@ resource citrix_quickdeploy_catalog default-power-schedule-catalog {
     template_image_id = "<Template Image ID>"
     machine_size = "d2asv5"
     storage_type = "StandardSSD_LRS"
-    number_of_machines = 2
+    number_of_users = 2
     max_users_per_vm = 4
     power_schedule = {}
 }
@@ -36,7 +36,7 @@ resource citrix_quickdeploy_catalog custom-power-schedule-catalog {
     template_image_id = "<Template Image ID>"
     machine_size = "d2asv5"
     storage_type = "StandardSSD_LRS"
-    number_of_machines = 4
+    number_of_users = 4
     max_users_per_vm = 4
     machine_naming_scheme = {
         naming_scheme = "example-vda-#"
@@ -69,7 +69,7 @@ resource citrix_quickdeploy_catalog domain-joined-catalog {
     template_image_id = "<Template Image ID>"
     machine_size = "d2asv5"
     storage_type = "StandardSSD_LRS"
-    number_of_machines = 2
+    number_of_users = 2
     max_users_per_vm = 4
     power_schedule = {}
     on_prem_connectivity = {
@@ -91,7 +91,7 @@ resource citrix_quickdeploy_catalog domain-joined-catalog {
 - `catalog_type` (String) Denotes how the machines in the catalog are allocated to a user. Choose between `MultiSession`, `SingleSessionStatic` and `SingleSessionRandom`.
 - `machine_size` (String) The Azure VM SKU to use for creating machines.
 - `name` (String) Name of the managed catalog.
-- `number_of_machines` (Number) Number of VMs that will be provisioned for this catalog. Defaults to `1`.
+- `number_of_users` (Number) Number of users for the catalog. Defaults to `1`.
 - `power_schedule` (Attributes) The power management schedule for the Citrix Managed catalog. (see [below for nested schema](#nestedatt--power_schedule))
 - `region` (String) The Azure region to deploy the managed catalog.
 - `storage_type` (String) Storage account type used for provisioned virtual machine disks on Azure. Storage types include: `Standard_LRS`, `StandardSSD_LRS` and `Premium_LRS`.
@@ -105,23 +105,21 @@ resource citrix_quickdeploy_catalog domain-joined-catalog {
 - `max_users_per_vm` (Number) Maximum number of concurrent users that could launch session on the same machine. Only allowed to have more than 1 concurrent user when `catalog_type` is `MultiSession`. Defaults to `1`.
 - `on_prem_connectivity` (Attributes) On-Premises connectivity configuration for creating a domain-joined catalog. (see [below for nested schema](#nestedatt--on_prem_connectivity))
 - `subscription_name` (String) The name of the Citrix Managed Azure subscription to deploy the managed catalog. Defaults to `Citrix Managed` if omitted.
-- `use_managed_disks` (Boolean) Indicate whether to use Azure managed disks for the provisioned virtual machine. Defaults to `true`.
 
 ### Read-Only
 
 - `id` (String) GUID identifier of the managed catalog.
+- `max_number_of_users` (Number) Maximum number of users allowed for the current catalog capacity.
 
 <a id="nestedatt--power_schedule"></a>
 ### Nested Schema for `power_schedule`
 
 Optional:
 
-- `off_peak_buffer_capacity` (Number) The percentage of machines in the delivery group that should be kept available in an idle state outside peak hours.
 - `off_peak_disconnected_session_action` (String) The action to be performed after a configurable period of a user session disconnecting outside peak hours. Choose between `Nothing`, `Suspend`, and `Shutdown`. Default is `Nothing`.
 - `off_peak_disconnected_session_timeout` (Number) The number of minutes before the configured action should be performed after a user session disconnectts outside peak hours.
 - `off_peak_extended_disconnect_timeout` (Number) The number of minutes before the second configured action should be performed after a user session disconnects outside peak hours.
 - `off_peak_min_instances` (Number) The minimum number of machines that should be powered on during off peak hours. Defaults to `0`. Can only be set to more than `0` if `catalog_type` is `Dedicated`.
-- `peak_buffer_capacity` (Number) The percentage of machines in the managed catalog that should be kept available in an idle state in peak hours.
 - `peak_disconnected_session_action` (String) The action to be performed after a configurable period of a user session disconnecting in peak hours. Choose between `Nothing`, `Suspend`, and `Shutdown`. Default is `Nothing`.
 - `peak_disconnected_session_timeout` (Number) The number of minutes before the configured action should be performed after a user session disconnects in peak hours.
 - `peak_end_time` (Number) The end time of peak hours (0-23).

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/citrix/terraform-provider-citrix
 go 1.24.1
 
 require (
-	github.com/citrix/citrix-daas-rest-go v1.0.26
+	github.com/citrix/citrix-daas-rest-go v1.0.27
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-azure-helpers v0.75.1

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0
 github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
-github.com/citrix/citrix-daas-rest-go v1.0.26 h1:+u9w0bS1thIUm5qvExh6b62pPOeU72nSHlCcZcNSTFQ=
-github.com/citrix/citrix-daas-rest-go v1.0.26/go.mod h1:4Me0VHpyxMYfPwpU2XWV0jOE2Jdz8MHNpge3MLD5B2E=
+github.com/citrix/citrix-daas-rest-go v1.0.27 h1:9WHnJs/mQdAPtc6YD+Audkix9mauBHi8xq4L0+rlpMA=
+github.com/citrix/citrix-daas-rest-go v1.0.27/go.mod h1:4Me0VHpyxMYfPwpU2XWV0jOE2Jdz8MHNpge3MLD5B2E=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/internal/daas/image_definition/image_version_util.go
+++ b/internal/daas/image_definition/image_version_util.go
@@ -62,7 +62,7 @@ func buildImageScheme(ctx context.Context, client *citrixdaasclient.CitrixDaasCl
 		// Set License Type
 		util.AppendNameValueStringPair(customProperties, "LicenseType", licenseType)
 		// Set Disk Encryption Set
-		if !azureImageSpecs.DiskEncryptionSet.IsNull() {
+		if !azureImageSpecs.DiskEncryptionSet.IsUnknown() && !azureImageSpecs.DiskEncryptionSet.IsNull() {
 			diskEncryptionSetModel := util.ObjectValueToTypedObject[util.AzureDiskEncryptionSetModel](ctx, diagnostics, azureImageSpecs.DiskEncryptionSet)
 			diskEncryptionSet := diskEncryptionSetModel.DiskEncryptionSetName.ValueString()
 			diskEncryptionSetRg := diskEncryptionSetModel.DiskEncryptionSetResourceGroup.ValueString()

--- a/internal/daas/machine_catalog/machine_config.go
+++ b/internal/daas/machine_catalog/machine_config.go
@@ -1258,7 +1258,9 @@ func (mc *AzureMachineConfigModel) RefreshProperties(ctx context.Context, diagno
 	// Refresh Service Offering
 	provScheme := catalog.GetProvisioningScheme()
 	if provScheme.GetServiceOffering() != "" {
-		mc.ServiceOffering = types.StringValue(provScheme.GetServiceOffering())
+		if !strings.EqualFold(mc.ServiceOffering.ValueString(), provScheme.GetServiceOffering()) {
+			mc.ServiceOffering = types.StringValue(provScheme.GetServiceOffering())
+		}
 	}
 
 	// Refresh Master Image for non PVS catalogs
@@ -1517,7 +1519,9 @@ func (mc *AwsMachineConfigModel) RefreshProperties(ctx context.Context, diagnost
 	// Refresh Service Offering
 	provScheme := catalog.GetProvisioningScheme()
 	if provScheme.GetServiceOffering() != "" {
-		mc.ServiceOffering = types.StringValue(provScheme.GetServiceOffering())
+		if !strings.EqualFold(mc.ServiceOffering.ValueString(), provScheme.GetServiceOffering()) {
+			mc.ServiceOffering = types.StringValue(provScheme.GetServiceOffering())
+		}
 	}
 
 	if provScheme.CurrentImageVersion != nil {
@@ -1602,7 +1606,9 @@ func (mc *AmazonWorkspacesCoreMachineConfigModel) RefreshProperties(ctx context.
 	// Refresh Service Offering
 	provScheme := catalog.GetProvisioningScheme()
 	if provScheme.GetServiceOffering() != "" {
-		mc.ServiceOffering = types.StringValue(provScheme.GetServiceOffering())
+		if !strings.EqualFold(mc.ServiceOffering.ValueString(), provScheme.GetServiceOffering()) {
+			mc.ServiceOffering = types.StringValue(provScheme.GetServiceOffering())
+		}
 	}
 
 	currentImage := provScheme.GetCurrentImageVersion()

--- a/internal/daas/policy_filters/access_control_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/access_control_policy_filter_data_source.go
@@ -62,7 +62,7 @@ func (d *accessControlPolicyFilterDataSource) Read(ctx context.Context, req data
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/access_control_policy_filter_resource.go
+++ b/internal/daas/policy_filters/access_control_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *accessControlFilterResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/branch_repeater_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/branch_repeater_policy_filter_data_source.go
@@ -62,7 +62,7 @@ func (d *branchRepeaterPolicyFilterDataSource) Read(ctx context.Context, req dat
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/branch_repeater_policy_filter_resource.go
+++ b/internal/daas/policy_filters/branch_repeater_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *branchRepeaterFilterResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/client_ip_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/client_ip_policy_filter_data_source.go
@@ -62,7 +62,7 @@ func (d *clientIPPolicyFilterDataSource) Read(ctx context.Context, req datasourc
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/client_ip_policy_filter_resource.go
+++ b/internal/daas/policy_filters/client_ip_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *clientIpFilterResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/client_name_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/client_name_policy_filter_data_source.go
@@ -62,7 +62,7 @@ func (d *clientNamePolicyFilterDataSource) Read(ctx context.Context, req datasou
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/client_name_policy_filter_resource.go
+++ b/internal/daas/policy_filters/client_name_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *clientNameFilterResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/client_platform_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/client_platform_policy_filter_data_source.go
@@ -67,7 +67,7 @@ func (d *clientPlatformPolicyFilterDataSource) Read(ctx context.Context, req dat
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/client_platform_policy_filter_resource.go
+++ b/internal/daas/policy_filters/client_platform_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *clientPlatformFilterResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/delivery_group_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/delivery_group_policy_filter_data_source.go
@@ -62,7 +62,7 @@ func (d *deliveryGroupPolicyFilterDataSource) Read(ctx context.Context, req data
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/delivery_group_policy_filter_resource.go
+++ b/internal/daas/policy_filters/delivery_group_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *deliveryGroupFilterResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/delivery_group_type_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/delivery_group_type_policy_filter_data_source.go
@@ -62,7 +62,7 @@ func (d *deliveryGroupTypePolicyFilterDataSource) Read(ctx context.Context, req 
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/delivery_group_type_policy_filter_resource.go
+++ b/internal/daas/policy_filters/delivery_group_type_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *deliveryGroupTypeFilterResource) Read(ctx context.Context, req resource
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/ou_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/ou_policy_filter_data_source.go
@@ -62,7 +62,7 @@ func (d *ouPolicyFilterDataSource) Read(ctx context.Context, req datasource.Read
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/ou_policy_filter_resource.go
+++ b/internal/daas/policy_filters/ou_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *ouFilterResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/policy_filter_common.go
+++ b/internal/daas/policy_filters/policy_filter_common.go
@@ -86,7 +86,7 @@ func createPolicyFilter(ctx context.Context, client *citrixdaasclient.CitrixDaas
 	return policyFilterCreated, nil
 }
 
-func getPolicyFilter(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diagnostics *diag.Diagnostics, policyFilterId string) (*citrixorchestration.FilterResponse, error) {
+func readPolicyFilter(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diagnostics *diag.Diagnostics, policyFilterId string) (*citrixorchestration.FilterResponse, error) {
 	getPolicyFilterRequest := client.ApiClient.GpoDAAS.GpoReadGpoFilter(ctx, policyFilterId)
 	policyFilter, httpResp, err := citrixdaasclient.ExecuteWithRetry[*citrixorchestration.FilterResponse](getPolicyFilterRequest, client)
 	if err != nil {
@@ -95,6 +95,21 @@ func getPolicyFilter(ctx context.Context, client *citrixdaasclient.CitrixDaasCli
 			return nil, fmt.Errorf("%w: %w", util.ErrPolicyFilterNotFound, err)
 		}
 
+		diagnostics.AddError(
+			"Error Reading Policy Filter "+policyFilterId,
+			"TransactionId: "+citrixdaasclient.GetTransactionIdFromHttpResponse(httpResp)+
+				"\nError message: "+util.ReadClientError(err),
+		)
+		return nil, err
+	}
+
+	return policyFilter, nil
+}
+
+func getPolicyFilter(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diagnostics *diag.Diagnostics, policyFilterId string) (*citrixorchestration.FilterResponse, error) {
+	getPolicyFilterRequest := client.ApiClient.GpoDAAS.GpoReadGpoFilter(ctx, policyFilterId)
+	policyFilter, httpResp, err := citrixdaasclient.ExecuteWithRetry[*citrixorchestration.FilterResponse](getPolicyFilterRequest, client)
+	if err != nil {
 		diagnostics.AddError(
 			"Error Reading Policy Filter "+policyFilterId,
 			"TransactionId: "+citrixdaasclient.GetTransactionIdFromHttpResponse(httpResp)+

--- a/internal/daas/policy_filters/tag_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/tag_policy_filter_data_source.go
@@ -62,7 +62,7 @@ func (d *tagPolicyFilterDataSource) Read(ctx context.Context, req datasource.Rea
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/tag_policy_filter_resource.go
+++ b/internal/daas/policy_filters/tag_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *tagFilterModel) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/user_policy_filter_data_source.go
+++ b/internal/daas/policy_filters/user_policy_filter_data_source.go
@@ -62,7 +62,7 @@ func (d *userPolicyFilterDataSource) Read(ctx context.Context, req datasource.Re
 	var err error
 	if !data.Id.IsNull() {
 		// Get refreshed policy set from Orchestration
-		policyFilter, err = getPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
+		policyFilter, err = readPolicyFilter(ctx, d.client, &resp.Diagnostics, data.Id.ValueString())
 		if err != nil {
 			// Check if this is a "policy filter not found" error
 			if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_filters/user_policy_filter_resource.go
+++ b/internal/daas/policy_filters/user_policy_filter_resource.go
@@ -91,7 +91,7 @@ func (r *userFilterResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	policyFilter, err := getPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
+	policyFilter, err := readPolicyFilter(ctx, r.client, &resp.Diagnostics, state.GetId())
 	if err != nil {
 		// Check if this is a "policy filter not found" error
 		if errors.Is(err, util.ErrPolicyFilterNotFound) {

--- a/internal/daas/policy_resource/policy_resource.go
+++ b/internal/daas/policy_resource/policy_resource.go
@@ -95,7 +95,7 @@ func (r *policyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	policy, err := GetPolicy(ctx, r.client, &resp.Diagnostics, state.Id.ValueString(), false, false)
+	policy, err := readPolicy(ctx, r.client, &resp.Diagnostics, state.Id.ValueString(), false, false)
 	if err != nil {
 		// Check if this is a "policy not found" error
 		if errors.Is(err, util.ErrPolicyNotFound) {
@@ -272,7 +272,7 @@ func createPolicy(ctx context.Context, client *citrixdaasclient.CitrixDaasClient
 	return policy, nil
 }
 
-func GetPolicy(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diagnostics *diag.Diagnostics, policyId string, withFilters bool, withSettings bool) (*citrixorchestration.PolicyResponse, error) {
+func readPolicy(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diagnostics *diag.Diagnostics, policyId string, withFilters bool, withSettings bool) (*citrixorchestration.PolicyResponse, error) {
 	getPolicyReq := client.ApiClient.GpoDAAS.GpoReadGpoPolicy(ctx, policyId)
 	getPolicyReq = getPolicyReq.WithFilters(withFilters)
 	getPolicyReq = getPolicyReq.WithSettings(withSettings)
@@ -283,6 +283,23 @@ func GetPolicy(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, d
 			return nil, fmt.Errorf("%w: %w", util.ErrPolicyNotFound, err)
 		}
 
+		diagnostics.AddError(
+			"Error reading Policy "+policyId,
+			"TransactionId: "+citrixdaasclient.GetTransactionIdFromHttpResponse(httpResp)+
+				"\nError message: "+util.ReadClientError(err),
+		)
+		return nil, err
+	}
+
+	return policy, nil
+}
+
+func GetPolicy(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, diagnostics *diag.Diagnostics, policyId string, withFilters bool, withSettings bool) (*citrixorchestration.PolicyResponse, error) {
+	getPolicyReq := client.ApiClient.GpoDAAS.GpoReadGpoPolicy(ctx, policyId)
+	getPolicyReq = getPolicyReq.WithFilters(withFilters)
+	getPolicyReq = getPolicyReq.WithSettings(withSettings)
+	policy, httpResp, err := citrixdaasclient.ExecuteWithRetry[*citrixorchestration.PolicyResponse](getPolicyReq, client)
+	if err != nil {
 		diagnostics.AddError(
 			"Error reading Policy "+policyId,
 			"TransactionId: "+citrixdaasclient.GetTransactionIdFromHttpResponse(httpResp)+

--- a/internal/examples/resources/citrix_quickdeploy_catalog/resource.tf
+++ b/internal/examples/resources/citrix_quickdeploy_catalog/resource.tf
@@ -8,7 +8,7 @@ resource citrix_quickdeploy_catalog default-power-schedule-catalog {
     template_image_id = "<Template Image ID>"
     machine_size = "d2asv5"
     storage_type = "StandardSSD_LRS"
-    number_of_machines = 2
+    number_of_users = 2
     max_users_per_vm = 4
     power_schedule = {}
 }
@@ -22,7 +22,7 @@ resource citrix_quickdeploy_catalog custom-power-schedule-catalog {
     template_image_id = "<Template Image ID>"
     machine_size = "d2asv5"
     storage_type = "StandardSSD_LRS"
-    number_of_machines = 4
+    number_of_users = 4
     max_users_per_vm = 4
     machine_naming_scheme = {
         naming_scheme = "example-vda-#"
@@ -55,7 +55,7 @@ resource citrix_quickdeploy_catalog domain-joined-catalog {
     template_image_id = "<Template Image ID>"
     machine_size = "d2asv5"
     storage_type = "StandardSSD_LRS"
-    number_of_machines = 2
+    number_of_users = 2
     max_users_per_vm = 4
     power_schedule = {}
     on_prem_connectivity = {

--- a/internal/quickdeploy/cma_catalog/managed_catalog_resource.go
+++ b/internal/quickdeploy/cma_catalog/managed_catalog_resource.go
@@ -87,6 +87,7 @@ func (r *citrixManagedCatalogResource) Create(ctx context.Context, req resource.
 	addCatalog.SetIsDomainJoined(false)
 	addCatalog.SetIsAzureAdJoined(false)
 	addCatalog.SetPersistStaticAllocatedVmDisks(true)
+	addCatalog.SetMinUniqueUsers(int32(plan.NumberOfUsers.ValueInt64()))
 
 	if !plan.MachineNamingScheme.IsNull() {
 		var namingScheme citrixquickdeploy.MachineNamingSchemeModel
@@ -109,7 +110,6 @@ func (r *citrixManagedCatalogResource) Create(ctx context.Context, req resource.
 	catalogScaleSettings := util.ObjectValueToTypedObject[PowerScheduleModel](ctx, &resp.Diagnostics, plan.PowerSchedule)
 	scaleSettings := getScaleSettingsRequestModel(ctx, &resp.Diagnostics, catalogScaleSettings)
 	// Set max instance to be the same as number of machines
-	scaleSettings.SetMaxInstances(int32(plan.NumberOfMachines.ValueInt64()))
 	catalogCapacity.SetScaleSettings(scaleSettings)
 
 	// Set static catalog capacity settings
@@ -164,7 +164,7 @@ func (r *citrixManagedCatalogResource) Create(ctx context.Context, req resource.
 	}
 
 	createManagedCatalogRequest := r.client.QuickDeployClient.CatalogCMD.ConfigureAndDeployCitrixManagedCatalogApi(ctx, r.client.ClientConfig.CustomerId, r.client.ClientConfig.SiteId)
-	createManagedCatalogRequest = createManagedCatalogRequest.Body(managedCatalogConfigBody)
+	createManagedCatalogRequest = createManagedCatalogRequest.CitrixManagedCatalogConfigDeployModel(managedCatalogConfigBody)
 
 	// Create new Citrix Managed Catalog
 	_, httpResp, err := citrixdaasclient.AddRequestData(createManagedCatalogRequest, r.client).Execute()
@@ -318,7 +318,7 @@ func (r *citrixManagedCatalogResource) Update(ctx context.Context, req resource.
 		templateImageUpdateModel.SetCitrixPrepared(templateImage.GetCitrixPrepared())
 
 		updateCatalogImageRequest := r.client.QuickDeployClient.CatalogCMD.UpdateCatalogImage(ctx, r.client.ClientConfig.CustomerId, r.client.ClientConfig.SiteId, catalogId)
-		updateCatalogImageRequest = updateCatalogImageRequest.Body(templateImageUpdateModel)
+		updateCatalogImageRequest = updateCatalogImageRequest.UpdateCatalogTemplateImageModel(templateImageUpdateModel)
 
 		// Update Citrix Managed Azure Template Image
 		_, httpResp, err := citrixdaasclient.AddRequestData(updateCatalogImageRequest, r.client).Execute()
@@ -358,9 +358,18 @@ func (r *citrixManagedCatalogResource) Update(ctx context.Context, req resource.
 	// Configure scale settings model
 	catalogScaleSettings := util.ObjectValueToTypedObject[PowerScheduleModel](ctx, &resp.Diagnostics, plan.PowerSchedule)
 	scaleSettings := getScaleSettingsRequestModel(ctx, &resp.Diagnostics, catalogScaleSettings)
+	var additionalUsers = plan.NumberOfUsers.ValueInt64() - state.NumberOfUsers.ValueInt64()
+	scaleSettings.SetAdditionalUsers(int32(additionalUsers))
+
+	// Get catalog capacity to workaround mandatory input for MaxInstances
+	catalogCapacitySettings, err := getManagedCatalogCapacityWithId(ctx, r.client, &resp.Diagnostics, catalog.GetId(), true)
+	if err != nil {
+		return
+	}
+	currentScaleSettings := catalogCapacitySettings.GetScaleSettings()
+	scaleSettings.SetMaxInstances(currentScaleSettings.GetMaxInstances())
+
 	// Set pending max instances to be the same as number of machines for update instead of max instances
-	scaleSettings.SetPendingMaxInstances(int32(plan.NumberOfMachines.ValueInt64()))
-	scaleSettings.SetMaxInstances(int32(state.NumberOfMachines.ValueInt64()))
 	catalogCapacity.SetScaleSettings(scaleSettings)
 
 	// Set static catalog capacity settings
@@ -368,7 +377,7 @@ func (r *citrixManagedCatalogResource) Update(ctx context.Context, req resource.
 	catalogCapacity.SetMultiSessionDisconnectedSessionTimeout(15)
 
 	updateCatalogCapacityRequest := r.client.QuickDeployClient.CatalogCMD.UpdateCatalogScaleConfiguration(ctx, r.client.ClientConfig.CustomerId, r.client.ClientConfig.SiteId, catalogId)
-	updateCatalogCapacityRequest = updateCatalogCapacityRequest.Body(catalogCapacity)
+	updateCatalogCapacityRequest = updateCatalogCapacityRequest.CatalogCapacitySettingsModel(catalogCapacity)
 
 	// Update Citrix Managed Catalog Capacity Settings
 	httpResp, err := citrixdaasclient.AddRequestData(updateCatalogCapacityRequest, r.client).Execute()
@@ -403,7 +412,7 @@ func (r *citrixManagedCatalogResource) Update(ctx context.Context, req resource.
 		return
 	}
 	// Get catalog capacity
-	catalogCapacitySettings, err := getManagedCatalogCapacityWithId(ctx, r.client, &resp.Diagnostics, catalog.GetId(), true)
+	catalogCapacitySettings, err = getManagedCatalogCapacityWithId(ctx, r.client, &resp.Diagnostics, catalog.GetId(), true)
 	if err != nil {
 		return
 	}
@@ -438,7 +447,7 @@ func (r *citrixManagedCatalogResource) Delete(ctx context.Context, req resource.
 
 	// Delete Citrix Managed Catalog
 	deleteCatalogRequest := r.client.QuickDeployClient.CatalogCMD.DeleteCustomerCatalog(ctx, r.client.ClientConfig.CustomerId, r.client.ClientConfig.SiteId, state.Id.ValueString())
-	deleteCatalogRequest = deleteCatalogRequest.Body(deleteModel)
+	deleteCatalogRequest = deleteCatalogRequest.DeleteCatalogModel(deleteModel)
 	httpResp, err := citrixdaasclient.AddRequestData(deleteCatalogRequest, r.client).Execute()
 
 	if err != nil {
@@ -660,8 +669,6 @@ func getScaleSettingsRequestModel(ctx context.Context, diagnostics *diag.Diagnos
 	scaleSettings.SetOffPeakDisconnectedSessionTimeout(int32(plan.OffPeakDisconnectedSessionTimeout.ValueInt64()))
 	scaleSettings.SetPeakExtendedDisconnectTimeoutMinutes(int32(plan.PeakExtendedDisconnectTimeout.ValueInt64()))
 	scaleSettings.SetOffPeakExtendedDisconnectTimeoutMinutes(int32(plan.OffPeakExtendedDisconnectTimeout.ValueInt64()))
-	scaleSettings.SetBufferCapacity(int32(plan.PeakBufferCapacity.ValueInt64()))
-	scaleSettings.SetOffPeakBufferCapacity(int32(plan.OffPeakBufferCapacity.ValueInt64()))
 	scaleSettings.SetPeakMinInstances(int32(plan.PeakMinInstances.ValueInt64()))
 	scaleSettings.SetMinInstances(int32(plan.OffPeakMinInstances.ValueInt64()))
 	scaleSettings.SetPeakDisconnectedSessionAction(citrixquickdeploy.SessionChangeHostingAction(plan.PeakDisconnectedSessionAction.ValueString()))
@@ -682,8 +689,11 @@ func getComputerWorkerRequestModel(plan CitrixManagedCatalogResourceModel) citri
 	var computerWorker citrixquickdeploy.CatalogComputeWorkerModel
 	computerWorker.SetInstanceTypeId(plan.MachineSize.ValueString())
 	computerWorker.SetStorageType(citrixquickdeploy.CatalogCapacityStorageType(plan.StorageType.ValueString()))
-	computerWorker.SetUseManagedDisks(plan.UseManagedDisks.ValueBool())
 	computerWorker.SetMaxUsersPerVM(int32(plan.MaxUsersPerVm.ValueInt64()))
+
+	// Always use Azure Hub and Managed Disks for managed catalogs
+	computerWorker.SetUseManagedDisks(true)
+	computerWorker.SetUseAzureHUB(true)
 
 	return computerWorker
 }

--- a/internal/quickdeploy/cma_catalog/managed_catalog_resource_model.go
+++ b/internal/quickdeploy/cma_catalog/managed_catalog_resource_model.go
@@ -16,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -37,8 +35,8 @@ type CitrixManagedCatalogResourceModel struct {
 	TemplateImageId     types.String `tfsdk:"template_image_id"`
 	MachineSize         types.String `tfsdk:"machine_size"`
 	StorageType         types.String `tfsdk:"storage_type"`
-	UseManagedDisks     types.Bool   `tfsdk:"use_managed_disks"`
-	NumberOfMachines    types.Int64  `tfsdk:"number_of_machines"`
+	NumberOfUsers       types.Int64  `tfsdk:"number_of_users"`
+	MaxNumberOfUsers    types.Int64  `tfsdk:"max_number_of_users"`
 	MaxUsersPerVm       types.Int64  `tfsdk:"max_users_per_vm"`
 	MachineNamingScheme types.Object `tfsdk:"machine_naming_scheme"` // MachineNamingSchemeModel
 	PowerSchedule       types.Object `tfsdk:"power_schedule"`        // PowerScheduleModel
@@ -114,21 +112,16 @@ func (CitrixManagedCatalogResourceModel) GetSchema() schema.Schema {
 					),
 				},
 			},
-			"use_managed_disks": schema.BoolAttribute{
-				Description: "Indicate whether to use Azure managed disks for the provisioned virtual machine. Defaults to `true`.",
-				Optional:    true,
-				Computed:    true,
-				Default:     booldefault.StaticBool(true),
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
-				},
-			},
-			"number_of_machines": schema.Int64Attribute{
-				Description: "Number of VMs that will be provisioned for this catalog. Defaults to `1`.",
+			"number_of_users": schema.Int64Attribute{
+				Description: "Number of users for the catalog. Defaults to `1`.",
 				Required:    true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
+			},
+			"max_number_of_users": schema.Int64Attribute{
+				Description: "Maximum number of users allowed for the current catalog capacity.",
+				Computed:    true,
 			},
 			"max_users_per_vm": schema.Int64Attribute{
 				Description: "Maximum number of concurrent users that could launch session on the same machine. Only allowed to have more than 1 concurrent user when `catalog_type` is `MultiSession`. Defaults to `1`.",
@@ -200,8 +193,6 @@ type PowerScheduleModel struct {
 	OffPeakDisconnectedSessionTimeout types.Int64  `tfsdk:"off_peak_disconnected_session_timeout"`
 	PeakExtendedDisconnectTimeout     types.Int64  `tfsdk:"peak_extended_disconnect_timeout"`
 	OffPeakExtendedDisconnectTimeout  types.Int64  `tfsdk:"off_peak_extended_disconnect_timeout"`
-	PeakBufferCapacity                types.Int64  `tfsdk:"peak_buffer_capacity"`
-	OffPeakBufferCapacity             types.Int64  `tfsdk:"off_peak_buffer_capacity"`
 	PeakMinInstances                  types.Int64  `tfsdk:"peak_min_instances"`
 	OffPeakMinInstances               types.Int64  `tfsdk:"off_peak_min_instances"`
 	PeakDisconnectedSessionAction     types.String `tfsdk:"peak_disconnected_session_action"`
@@ -252,24 +243,6 @@ func (PowerScheduleModel) GetSchema() schema.SingleNestedAttribute {
 				Default:     int64default.StaticInt64(0),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(0),
-				},
-			},
-			"peak_buffer_capacity": schema.Int64Attribute{
-				Description: "The percentage of machines in the managed catalog that should be kept available in an idle state in peak hours.",
-				Optional:    true,
-				Computed:    true,
-				Default:     int64default.StaticInt64(0),
-				Validators: []validator.Int64{
-					int64validator.Between(0, 100),
-				},
-			},
-			"off_peak_buffer_capacity": schema.Int64Attribute{
-				Description: "The percentage of machines in the delivery group that should be kept available in an idle state outside peak hours.",
-				Optional:    true,
-				Computed:    true,
-				Default:     int64default.StaticInt64(0),
-				Validators: []validator.Int64{
-					int64validator.Between(0, 100),
 				},
 			},
 			"peak_min_instances": schema.Int64Attribute{
@@ -403,6 +376,9 @@ func (OnPremConnectivityModel) GetAttributes() map[string]schema.Attribute {
 func (r CitrixManagedCatalogResourceModel) RefreshPropertyValues(ctx context.Context, diagnostics *diag.Diagnostics, catalog *citrixquickdeploy.CatalogOverview, capacity *citrixquickdeploy.CatalogCapacitySettingsModel, region *citrixquickdeploy.DeploymentRegionModel) CitrixManagedCatalogResourceModel {
 	r.Id = types.StringValue(catalog.GetId())
 	r.Name = types.StringValue(catalog.GetName())
+	r.NumberOfUsers = types.Int64Value(int64(catalog.GetNumOfUsers()))
+	r.MaxNumberOfUsers = types.Int64Value(int64(catalog.GetMaxNumOfUsers()))
+
 	sessionSupport := catalog.GetSessionSupport()
 	allocationType := catalog.GetAllocationType()
 	switch sessionSupport {
@@ -426,9 +402,7 @@ func (r CitrixManagedCatalogResourceModel) RefreshPropertyValues(ctx context.Con
 	computerWorker := capacity.GetComputeWorker()
 	r.MachineSize = types.StringValue(computerWorker.GetInstanceTypeId())
 	r.StorageType = types.StringValue(string(computerWorker.GetStorageType()))
-	r.UseManagedDisks = types.BoolValue(computerWorker.GetUseManagedDisks())
 	r.MaxUsersPerVm = types.Int64Value(int64(computerWorker.GetMaxUsersPerVM()))
-	r.NumberOfMachines = types.Int64Value(int64(capacity.ScaleSettings.GetMaxInstances()))
 
 	r = r.updatePlanWithPowerSchedule(ctx, diagnostics, capacity)
 
@@ -448,8 +422,6 @@ func (r CitrixManagedCatalogResourceModel) updatePlanWithPowerSchedule(ctx conte
 	powerSchedule.OffPeakDisconnectedSessionTimeout = types.Int64Value(int64(scaleSettings.GetOffPeakDisconnectedSessionTimeout()))
 	powerSchedule.PeakExtendedDisconnectTimeout = types.Int64Value(int64(scaleSettings.GetPeakExtendedDisconnectTimeoutMinutes()))
 	powerSchedule.OffPeakExtendedDisconnectTimeout = types.Int64Value(int64(scaleSettings.GetOffPeakExtendedDisconnectTimeoutMinutes()))
-	powerSchedule.PeakBufferCapacity = types.Int64Value(int64(scaleSettings.GetBufferCapacity()))
-	powerSchedule.OffPeakBufferCapacity = types.Int64Value(int64(scaleSettings.GetOffPeakBufferCapacity()))
 	powerSchedule.PeakMinInstances = types.Int64Value(int64(scaleSettings.GetPeakMinInstances()))
 	powerSchedule.OffPeakMinInstances = types.Int64Value(int64(scaleSettings.GetMinInstances()))
 	powerSchedule.PeakDisconnectedSessionAction = types.StringValue(string(scaleSettings.GetPeakDisconnectedSessionAction()))

--- a/internal/quickdeploy/cma_image/template_image_resource.go
+++ b/internal/quickdeploy/cma_image/template_image_resource.go
@@ -103,7 +103,7 @@ func (r *citrixManagedAzureImageResource) Create(ctx context.Context, req resour
 	importImageBody.SetAzureSubscriptionId(subscription.GetSubscriptionId())
 
 	importTemplateImageRequest := r.client.QuickDeployClient.MasterImageCMD.ImportTemplateImage(ctx, r.client.ClientConfig.CustomerId, r.client.ClientConfig.SiteId)
-	importTemplateImageRequest = importTemplateImageRequest.Body(importImageBody)
+	importTemplateImageRequest = importTemplateImageRequest.ImportTemplateImageModel(importImageBody)
 
 	// Import new Citrix Managed Azure Template Image
 	importImageResponse, httpResp, err := citrixdaasclient.AddRequestData(importTemplateImageRequest, r.client).Execute()
@@ -198,7 +198,7 @@ func (r *citrixManagedAzureImageResource) Update(ctx context.Context, req resour
 	templateImageUpdateBody.SetNewNotes(plan.Notes.ValueString())
 
 	updateTemplateImageRequest := r.client.QuickDeployClient.MasterImageCMD.UpdateTemplateImage(ctx, r.client.ClientConfig.CustomerId, r.client.ClientConfig.SiteId, imageId)
-	updateTemplateImageRequest = updateTemplateImageRequest.Body(templateImageUpdateBody)
+	updateTemplateImageRequest = updateTemplateImageRequest.UpdateTemplateImageModel(templateImageUpdateBody)
 
 	// Update Citrix Managed Azure Template Image
 	httpResp, err := citrixdaasclient.AddRequestData(updateTemplateImageRequest, r.client).Execute()

--- a/internal/test/quickdeploy_catalog_resource_test.go
+++ b/internal/test/quickdeploy_catalog_resource_test.go
@@ -78,8 +78,8 @@ func TestQuickDeployCatalogResource(t *testing.T) {
 					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "name", name),
 					// Verify catalog type
 					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "catalog_type", "MultiSession"),
-					// Verify number of machines
-					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "number_of_machines", "1"),
+					// Verify number of users
+					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "number_of_users", "2"),
 					// Verify subscription name
 					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "subscription_name", "Citrix Managed"),
 				),
@@ -107,8 +107,8 @@ func TestQuickDeployCatalogResource(t *testing.T) {
 					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "name", name),
 					// Verify catalog type
 					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "catalog_type", "MultiSession"),
-					// Verify number of machines
-					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "number_of_machines", "2"),
+					// Verify number of users
+					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "number_of_users", "10"),
 					// Verify subscription name
 					resource.TestCheckResourceAttr("citrix_quickdeploy_catalog.test-catalog", "subscription_name", "Citrix Managed"),
 				),
@@ -128,15 +128,13 @@ var (
 		template_image_id = data.citrix_quickdeploy_template_image.test_image.id
 		machine_size = "d8asv5"
 		storage_type = "StandardSSD_LRS"
-		number_of_machines = 1
+		number_of_users = 2
 		max_users_per_vm = 8
 		machine_naming_scheme = {
 			naming_scheme = "gotest-###"
 			naming_scheme_type = "Numeric"
 		}
 		power_schedule = {
-			peak_buffer_capacity = 30
-			off_peak_buffer_capacity = 15
 			peak_min_instances = 1
 			off_peak_min_instances = 1
 			weekdays = ["monday", "tuesday", "wednesday", "thursday", "friday"]
@@ -156,15 +154,13 @@ var (
 		template_image_id = data.citrix_quickdeploy_template_image.test_image.id
 		machine_size = "d8asv5"
 		storage_type = "StandardSSD_LRS"
-		number_of_machines = 2
+		number_of_users = 10
 		max_users_per_vm = 8
 		machine_naming_scheme = {
 			naming_scheme = "gotest-###"
 			naming_scheme_type = "Numeric"
 		}
 		power_schedule = {
-			peak_buffer_capacity = 30
-			off_peak_buffer_capacity = 15
 			peak_min_instances = 1
 			off_peak_min_instances = 1
 			weekdays = ["monday", "tuesday", "wednesday", "thursday", "friday"]

--- a/internal/util/common.go
+++ b/internal/util/common.go
@@ -1796,6 +1796,10 @@ func PollZone(ctx context.Context, client *citrixdaasclient.CitrixDaasClient, zo
 		continue
 	}
 
+	if isZoneBeingDeleted {
+		err = fmt.Errorf("Timed out waiting for zone %s to be deleted", zoneName)
+	}
+
 	return zone, err
 }
 

--- a/scripts/object-ids-helper/cvad-object-ids.ps1
+++ b/scripts/object-ids-helper/cvad-object-ids.ps1
@@ -64,10 +64,10 @@ Param (
 
 function Get-Site {
     if ($script:onPremise) {
-        $siteRequest = "https://$script:hostname/citrix/orchestration/api/me"
+        $siteRequest = "https://$($script:hostname)/citrix/orchestration/api/me"
     }
     else {
-        $siteRequest = "https://$script:hostname/cvad/manage/me"
+        $siteRequest = "https://$($script:hostname)/cvad/manage/me"
     }
 
     $response = Start-GetRequest -url $siteRequest
@@ -76,10 +76,10 @@ function Get-Site {
 
 function Get-RequestBaseUrl {
     if ($script:onPremise) {
-        $url = "https://$script:hostname/citrix/orchestration/api/CitrixOnPremises/$script:siteId"
+        $url = "https://$($script:hostname)/citrix/orchestration/api/CitrixOnPremises/$($script:siteId)"
     }
     else {
-        $url = "https://$script:hostname/cvad/manage"
+        $url = "https://$($script:hostname)/cvad/manage"
     }
 
     $script:urlBase = $url
@@ -144,8 +144,8 @@ function Invoke-WebRequestWithRetry {
 
 function Get-AuthToken {
     if ($script:onPremise) {
-        $url = "https://$script:hostname/citrix/orchestration/api/tokens"
-        $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}\{1}:{2}" -f $script:domainFqdn, $script:clientId, $script:clientSecret)))
+        $url = "https://$($script:hostname)/citrix/orchestration/api/tokens"
+        $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}\{1}:{2}" -f $($script:domainFqdn), $($script:clientId), $($script:clientSecret))))
         $basicAuth = "Basic $base64AuthInfo"
         $response = Invoke-WebRequestWithRetry -Uri $url -Method 'POST' -Headers @{Authorization = $basicAuth } 
         $jsonObj = ConvertFrom-Json $([String]::new($response.Content))
@@ -165,22 +165,22 @@ function Get-AuthToken {
         }
 
         if ($script:environment -eq "Production") {
-            $url = "https://api.cloud.com/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.cloud.com/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "Staging") {
-            $url = "https://api.cloudburrito.com/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.cloudburrito.com/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "Japan") {
-            $url = "https://api.citrixcloud.jp/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.citrixcloud.jp/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "JapanStaging") {
-            $url = "https://api.citrixcloud-test.jp/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.citrixcloud-test.jp/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "Gov") {
-            $url = "https://api.citrixcloud.us/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.citrixcloud.us/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "GovStaging") {
-            $url = "https://api.citrixcloud-test.us/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.citrixcloud-test.us/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
 
         $body = @{
@@ -213,11 +213,11 @@ function Start-GetRequest {
     else {
         $headers = @{
             "Authorization"     = "CwsAuth Bearer=$token"
-            "Citrix-CustomerId" = $script:customerId
+            "Citrix-CustomerId" = $($script:customerId)
             "Accept"            = "application/json, text/plain, */*"
         }
         if ($null -ne $script:siteId) {
-            $headers["Citrix-InstanceId"] = $script:siteId
+            $headers["Citrix-InstanceId"] = $($script:siteId)
         }
     }
     
@@ -255,10 +255,10 @@ function Get-UrlForWemObjects {
     }
 
     if ($requestPath -eq "sites") {
-        return "https://$script:wemHostName/services/wem/sites?includeHidden=true&includeUnboundAgentsSite=true"
+        return "https://$($script:wemHostName)/services/wem/sites?includeHidden=true&includeUnboundAgentsSite=true"
     }
     else {
-        return "https://$script:wemHostName/services/wem/machines"
+        return "https://$($script:wemHostName)/services/wem/machines"
     }
 }
 
@@ -290,7 +290,7 @@ function Get-ResourceList {
 
     $object_list   = @()
 
-    $url = "$script:urlBase/$requestPath"
+    $url = "$($script:urlBase)/$requestPath"
 
     # Update url for WEM Objects
     if ($resourceProviderName -in "wem_configuration_set", "wem_directory_object") {

--- a/scripts/onboarding-helper/terraform-onboarding.ps1
+++ b/scripts/onboarding-helper/terraform-onboarding.ps1
@@ -94,10 +94,10 @@ Param (
 
 function Get-Site {
     if ($script:onPremise) {
-        $siteRequest = "https://$script:hostname/citrix/orchestration/api/me"
+        $siteRequest = "https://$($script:hostname)/citrix/orchestration/api/me"
     }
     else {
-        $siteRequest = "https://$script:hostname/cvad/manage/me"
+        $siteRequest = "https://$($script:hostname)/cvad/manage/me"
     }
 
     $response = Start-GetRequest -url $siteRequest
@@ -106,10 +106,10 @@ function Get-Site {
 
 function Get-RequestBaseUrl {
     if ($script:onPremise) {
-        $url = "https://$script:hostname/citrix/orchestration/api/CitrixOnPremises/$script:siteId"
+        $url = "https://$($script:hostname)/citrix/orchestration/api/CitrixOnPremises/$($script:siteId)"
     }
     else {
-        $url = "https://$script:hostname/cvad/manage"
+        $url = "https://$($script:hostname)/cvad/manage"
     }
 
     $script:urlBase = $url
@@ -174,8 +174,8 @@ function Invoke-WebRequestWithRetry {
 
 function Get-AuthToken {
     if ($script:onPremise) {
-        $url = "https://$script:hostname/citrix/orchestration/api/tokens"
-        $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}\{1}:{2}" -f $script:domainFqdn, $script:clientId, $script:clientSecret)))
+        $url = "https://$($script:hostname)/citrix/orchestration/api/tokens"
+        $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}\{1}:{2}" -f $($script:domainFqdn), $($script:clientId), $($script:clientSecret))))
         $basicAuth = "Basic $base64AuthInfo"
         $response = Invoke-WebRequestWithRetry -Uri $url -Method 'POST' -Headers @{Authorization = $basicAuth } 
         $jsonObj = ConvertFrom-Json $response.Content
@@ -195,22 +195,22 @@ function Get-AuthToken {
         }
 
         if ($script:environment -eq "Production") {
-            $url = "https://api.cloud.com/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.cloud.com/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "Staging") {
-            $url = "https://api.cloudburrito.com/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.cloudburrito.com/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "Japan") {
-            $url = "https://api.citrixcloud.jp/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.citrixcloud.jp/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "JapanStaging") {
-            $url = "https://api.citrixcloud-test.jp/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.citrixcloud-test.jp/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "Gov") {
-            $url = "https://api.citrixcloud.us/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.citrixcloud.us/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "GovStaging") {
-            $url = "https://api.citrixcloud-test.us/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.citrixcloud-test.us/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
 
         $body = @{
@@ -243,11 +243,11 @@ function Start-GetRequest {
     else {
         $headers = @{
             "Authorization"     = "CwsAuth Bearer=$token"
-            "Citrix-CustomerId" = $script:customerId
+            "Citrix-CustomerId" = $($script:customerId)
             "Accept"            = "application/json, text/plain, */*"
         }
         if ($null -ne $script:siteId) {
-            $headers["Citrix-InstanceId"] = $script:siteId
+            $headers["Citrix-InstanceId"] = $($script:siteId)
         }
     }
     
@@ -273,8 +273,8 @@ function New-RequiredFiles {
         $config = @"
 provider "citrix" {
     cvad_config = {
-        hostname                    = "$script:hostname"
-        client_id                   = "$script:domainFqdn\\$script:clientId"
+        hostname                    = "$($script:hostname)"
+        client_id                   = "$($script:domainFqdn)\\$($script:clientId)"
         # client_secret               = "$secretValue"
         disable_ssl_verification    = $disable_ssl_verification
     }
@@ -286,11 +286,11 @@ provider "citrix" {
         $config = @"
 provider "citrix" {
     cvad_config = {
-        customer_id                 = "$script:customerId"
-        client_id                   = "$script:clientId"
+        customer_id                 = "$($script:customerId)"
+        client_id                   = "$($script:clientId)"
         # client_secret               = "$secretValue"
-        hostname                    = "$script:hostname"
-        environment                 = "$script:environment"
+        hostname                    = "$($script:hostname)"
+        environment                 = "$($script:environment)"
     }
 }
 "@
@@ -331,7 +331,7 @@ function Get-ResourceList {
         [string] $resourceProviderName
     )
 
-    $url = "$script:urlBase/$requestPath"
+    $url = "$($script:urlBase)/$requestPath"
 
     
     # Check if the resource provider is supported in the current environment (eg. WEM is not supported for most environments)

--- a/scripts/storefront-onboarding-helper/storefront-terraform-onboarding.ps1
+++ b/scripts/storefront-onboarding-helper/storefront-terraform-onboarding.ps1
@@ -109,9 +109,9 @@ function New-RequiredFiles {
     $config = @"
 provider "citrix" {
     storefront_remote_host = {
-        computer_name                = "$script:computerName"
-        ad_admin_username            = "$script:processedadUsername"
-        ad_admin_password            = "$script:adPassword"
+        computer_name                = "$($script:computerName)"
+        ad_admin_username            = "$($script:processedadUsername)"
+        ad_admin_password            = "$($script:adPassword)"
         disable_ssl_verification       =  $disableSSL
     }
 }

--- a/scripts/wem-helper/wem-terraform-onboarding.ps1
+++ b/scripts/wem-helper/wem-terraform-onboarding.ps1
@@ -79,13 +79,13 @@ Param (
 ### Helper Functions ###
 
 function Get-Site {
-    $siteRequest = "https://$script:hostname/cvad/manage/me"
+    $siteRequest = "https://$($script:hostname)/cvad/manage/me"
     $response = Start-GetRequest -url $siteRequest
     $script:siteId = $response.Customers[0].Sites[0].Id
 }
 
 function Get-RequestBaseUrl {
-    $url = "https://$script:hostname/cvad/manage"
+    $url = "https://$($script:hostname)/cvad/manage"
     $script:urlBase = $url
 }
 
@@ -161,10 +161,10 @@ function Get-AuthToken {
         }
 
         if ($script:environment -eq "Production") {
-            $url = "https://api.cloud.com/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.cloud.com/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
         elseif ($script:environment -eq "Staging") {
-            $url = "https://api.cloudburrito.com/cctrustoauth2/$script:customerId/tokens/clients"
+            $url = "https://api.cloudburrito.com/cctrustoauth2/$($script:customerId)/tokens/clients"
         }
 
         $body = @{
@@ -192,11 +192,11 @@ function Start-GetRequest {
     
         $headers = @{
             "Authorization"     = "CwsAuth Bearer=$token"
-            "Citrix-CustomerId" = $script:customerId
+            "Citrix-CustomerId" = $($script:customerId)
             "Accept"            = "application/json, text/plain, */*"
         }
         if ($null -ne $script:siteId) {
-            $headers["Citrix-InstanceId"] = $script:siteId
+            $headers["Citrix-InstanceId"] = $($script:siteId)
         }
     
     
@@ -221,11 +221,11 @@ function New-RequiredFiles {
         $config = @"
 provider "citrix" {
     cvad_config = {
-        customer_id                 = "$script:customerId"
-        client_id                   = "$script:clientId"
+        customer_id                 = "$($script:customerId)"
+        client_id                   = "$($script:clientId)"
         # client_secret               = "$secretValue"
-        hostname                    = "$script:hostname"
-        environment                 = "$script:environment"
+        hostname                    = "$($script:hostname)"
+        environment                 = "$($script:environment)"
     }
 }
 "@
@@ -272,10 +272,10 @@ function Get-UrlForWemObjects {
 
 
     if ($requestPath -eq "sites") {
-        return "https://$script:wemHostName/services/wem/sites?includeHidden=true&includeUnboundAgentsSite=true"
+        return "https://$($script:wemHostName)/services/wem/sites?includeHidden=true&includeUnboundAgentsSite=true"
     }
     else {
-        return "https://$script:wemHostName/services/wem/machines"
+        return "https://$($script:wemHostName)/services/wem/machines"
     }
 }
 
@@ -305,7 +305,7 @@ function Get-ResourceList {
         [string] $resourceProviderName
     )
 
-    $url = "$script:urlBase/$requestPath"
+    $url = "$($script:urlBase)/$requestPath"
 
     # Update url for WEM Objects
     if ($resourceProviderName -in "wem_configuration_set", "wem_directory_object") {


### PR DESCRIPTION
**Breaking Change:**
- `citrix_quickdeploy_catalog` resource now takes `number_of_users` instead of `number_of_machines` as input.

**Bugfixes:**
- Check if `disk_encryption_set` is unknown when creating image version. Fixes #333
- Add resource not found errors to diagnostics when creating policy filters. Fixes #334
- Throw error if zone deletion times out. Fixes #335
- Fix inconsistent apply issue on machine catalog when there is a casing mismatch on service offering. Fixes #323