### PR TITLE
Fix onboarding script only importing the first 250 objects per resource type

### DIFF
--- a/scripts/onboarding-helper/terraform-onboarding.ps1
+++ b/scripts/onboarding-helper/terraform-onboarding.ps1
@@ -345,27 +345,74 @@ function Start-GetRequest {
         [parameter(Mandatory = $true)][string] $url
     )
 
-    $token = Get-AuthToken
-    if ($script:onPremise) {
-        $headers = @{
-            Authorization = "Bearer $token"
+    # Requests use the service's default page size (250 items). When a response carries a ContinuationToken there are
+    # more items than fit on one page, so keep following the token and merge every page's Items into the first response.
+    $maxPages = 1000
+    $requestUrl = $url
+    $aggregatedResponse = $null
+    $allItems = [System.Collections.Generic.List[object]]::new()
+    $previousContinuationToken = $null
+    $pageNumber = 0
+
+    while ($true) {
+        $token = Get-AuthToken
+        if ($script:onPremise) {
+            $headers = @{
+                Authorization = "Bearer $token"
+            }
         }
+        else {
+            $headers = @{
+                "Authorization"     = "CwsAuth Bearer=$token"
+                "Citrix-CustomerId" = $($script:customerId)
+                "Accept"            = "application/json"
+            }
+            if ($null -ne $script:siteId) {
+                $headers["Citrix-InstanceId"] = $($script:siteId)
+            }
+        }
+
+        $response = Invoke-WebRequestWithRetry -Uri $requestUrl -Method 'GET' -Headers $headers -ContentType $contentType
+        $responseJsonString = [regex]::Replace($response.Content, '\\x([0-9A-Fa-f]{2})', { param($hex) '\u{0}' -f $hex.Groups[1].Value.PadLeft(4,'0') })
+        $jsonObj = ConvertFrom-Json $responseJsonString
+        $pageNumber++
+
+        # The first page defines the response shape (Items plus sibling properties); later pages only contribute Items.
+        if ($null -eq $aggregatedResponse) {
+            $aggregatedResponse = $jsonObj
+        }
+        if ($null -ne $jsonObj.Items) {
+            $allItems.AddRange([object[]]$jsonObj.Items)
+        }
+
+        $continuationToken = $jsonObj.ContinuationToken
+        if ([string]::IsNullOrEmpty($continuationToken)) {
+            break
+        }
+        # Guard against a server that keeps handing back the same token, which would otherwise loop forever.
+        if ($continuationToken -eq $previousContinuationToken) {
+            Write-Verbose "Continuation token for $url did not advance. Stopping after $pageNumber page(s)."
+            break
+        }
+        if ($pageNumber -ge $maxPages) {
+            Write-Warning "Reached the $maxPages page limit while paging $url. Some items may be missing."
+            break
+        }
+
+        $previousContinuationToken = $continuationToken
+        $separator = if ($url.Contains("?")) { "&" } else { "?" }
+        $requestUrl = "$url$separator" + "continuationtoken=$([System.Uri]::EscapeDataString($continuationToken))"
+        Write-Verbose "Fetching page $($pageNumber + 1) of $url ($($allItems.Count) items so far)."
     }
-    else {
-        $headers = @{
-            "Authorization"     = "CwsAuth Bearer=$token"
-            "Citrix-CustomerId" = $($script:customerId)
-            "Accept"            = "application/json"
-        }
-        if ($null -ne $script:siteId) {
-            $headers["Citrix-InstanceId"] = $($script:siteId)
-        }
+
+    # Only rewrite Items when multiple pages were merged; single-page responses (and responses without an Items
+    # property, such as the cloud resource locations endpoint) are returned exactly as received.
+    if ($pageNumber -gt 1) {
+        $aggregatedResponse.Items = $allItems.ToArray()
+        Write-Verbose "Retrieved $($allItems.Count) items from $url across $pageNumber pages."
     }
-    
-    $response = Invoke-WebRequestWithRetry -Uri $url -Method 'GET' -Headers $headers -ContentType $contentType
-    $responseJsonString = [regex]::Replace($response.Content, '\\x([0-9A-Fa-f]{2})', { param($hex) '\u{0}' -f $hex.Groups[1].Value.PadLeft(4,'0') })
-    $jsonObj = ConvertFrom-Json $responseJsonString
-    return $jsonObj
+
+    return $aggregatedResponse
 }
 
 function New-RequiredFiles {


### PR DESCRIPTION
## Summary

Fixes the onboarding helper script (`scripts/onboarding-helper/terraform-onboarding.ps1`) only enumerating the **first 250 objects** of each resource type.

`Start-GetRequest` issued a single `GET` and returned the first page as-is. The Citrix DaaS / Orchestration query APIs page their results (default 250 per page) and return a `ContinuationToken` when more results remain. Because the script never followed the token, any resource type with more than 250 objects on the site was silently truncated — those resources were never written to `import.tf`, never imported into state, and never appeared in the generated `.tf` files.

Since every list call (resource enumeration, policies/settings/filters, Quick Deploy images) funnels through `Start-GetRequest`, fixing it there covers all of them with **no call-site changes**.

Relates to #368.

## Changes

- `Start-GetRequest` now follows the response `ContinuationToken`, requesting subsequent pages and merging every page's `Items` into the first response before returning.
- Guards included:
  - stop if the server returns a non-advancing `ContinuationToken` (avoids an infinite loop),
  - a page-count cap as a final safety valve.
- Single-page responses, and responses without an `Items` collection (e.g. the cloud resource locations endpoint), are returned exactly as received — behavior is unchanged for everything that already fit on one page.

## Testing

- `terraform-onboarding.ps1` parses with no syntax errors (`[System.Management.Automation.Language.Parser]::ParseFile`).
- Paging logic validated against a mocked transport: multi-page merge via `ContinuationToken`, correct `?`/`&` separator selection for URLs with and without an existing query string, single-page and non-`Items` responses returned untouched.
